### PR TITLE
Chore/add releases slack notification wf

### DIFF
--- a/.github/workflows/send-slack-notification.yml
+++ b/.github/workflows/send-slack-notification.yml
@@ -1,0 +1,15 @@
+name: Trigger Slack Notification on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  notify_slack:
+    if: github.event.pull_request.merged == true
+    uses: chargebee/cb-cicd-pipelines/.github/workflows/send-slack-notification.yml@v2.35.0
+    secrets: inherit
+  send_notification:
+    uses: chargebee/cb-idp/.github/workflows/deployment-notification-call.yml@main


### PR DESCRIPTION
Chore by M Bhavitra
Subject: Action Required: Merging Branch for Slack Notifications
We have created a branch named chore/add-releases-slack-notification-wf in the repositories listed [here](https://docs.google.com/spreadsheets/d/1yESGvbqXnA1dgz0H3Co9eg4xijwlR3iqL-2e1qxC1-I/edit?usp=sharing). This branch includes a GitHub workflow designed to automatically send Slack notifications to the [#release-tracker](https://chargebee.slack.com/archives/C07JKG59V9P) channel for all releases.
Please merge these changes into your respective repositories to activate this feature. Once you have completed the merge, kindly update the status in the last column of the provided [tracking sheet](https://mychargebee.atlassian.net/wiki/spaces/~346808425/pages/3492413453/Repos+addition+to+Unified+Release+Notes+slack+channel) to merged.
Thank you for your cooperation!

For taxes these are the repos