### PR TITLE
Fix Security vulnerability with jackson dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ dependencies {
     implementation 'io.gsonfire:gson-fire:1.8.5'
     implementation 'javax.ws.rs:jsr311-api:1.1.1'
     implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.12.7'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.15.0'
     implementation 'org.apache.commons:commons-lang3:3.13.0'
     implementation 'jakarta.annotation:jakarta.annotation-api:1.3.5'
     testImplementation 'org.mockito:mockito-core:5.6.0'


### PR DESCRIPTION
The version 0.2.6 of jackson-databind-nullable dependency has high vulnerability to DOS (Denial of Service) attacks. It has been identified during the scanning with synk security tool.  Hence we are changing it to a version 2.12.7.1 which has been identified as a more secure version by synk.

<img width="879" alt="image" src="https://github.com/user-attachments/assets/7ef26863-0e52-4874-ad5a-ef2dd0bc456f">

Built jar with java 8 and pushed to  cb-app and ran the regression
cbapp PR - https://chargebee.slack.com/archives/C03NKLVB2EA/p1733566316804839

Built jar with java 17, imported it to cb-taxadapter-service locally, ran units and integrations test cases. All passing. Attaching the files. 

<img width="573" alt="image" src="https://github.com/user-attachments/assets/52b54834-4e2d-4595-872f-0f7de6d06f99">

[mvn_clean_uts.txt](https://github.com/user-attachments/files/18059606/mvn_clean_uts.txt)
[mvn_compile_9thDec.txt](https://github.com/user-attachments/files/18059607/mvn_compile_9thDec.txt)
[Uploading mvn_integration_test_results_9thDec.txt…]()


