### PR TITLE
Git Hub Secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,5 @@ jobs:
     uses: chargebee/cb-cicd-pipelines/.github/workflows/gradle-library-ci-workflow.yml@v1.23.0
     secrets: inherit
     with:
-      CI_ROLE: arn:aws:iam::606027973764:role/cb-builds-us-e1-cb_provider_spi-ci-role
+      CI_ROLE: ${{ secrets.CI_ROLE }}
       GENERATE_OPEN_API: true


### PR DESCRIPTION
CI_ROLE in github workflow contains confidential data like AWS account ID. Hence the CI_ROLE attribute has been added as a Github secret key. Now we can store it is ${{ secrets.CI_ROLE }}. 