### PR TITLE
githubsecret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,5 @@ jobs:
     uses: chargebee/cb-cicd-pipelines/.github/workflows/gradle-library-ci-workflow.yml@v1.23.0
     secrets: inherit
     with:
-      CI_ROLE: ${{ secrets.CI_ROLE }}
+      CI_ROLE: ${{secrets.CI_ROLE}}
       GENERATE_OPEN_API: true


### PR DESCRIPTION
CI_ROLE in github workflow contains confidential data like AWS account ID. Hence the CI_ROLE attribute has been added as a Github secret key. Now we can store it as ${{ secrets.CI_ROLE }}. 