### PR TITLE
TAXENGG-2951 Defined headers and security section for apis

### DIFF
--- a/spec/spi/openapi_location_validation.yml
+++ b/spec/spi/openapi_location_validation.yml
@@ -106,6 +106,9 @@ paths:
         '503':
           $ref: './schemas/errors.yml#/components/responses/Error503'
 components:
+  securitySchemes:
+    Authorization:
+      $ref: './schemas/headers.yml#/components/securitySchemes/Authorization'
   schemas:
     LocationValidationEvidence:
       type: object
@@ -273,15 +276,5 @@ components:
           phone: IN
           taxRegistrationNumber: FR
           address: US
-  securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-    apiKey:
-      type: apiKey
-      description: Bearer token based authentication.
-      name: bearer
-      in: header
 security:
-  - bearerAuth: []
-  - apiKey: []
+  - Authorization: []

--- a/spec/spi/openapi_tax.yml
+++ b/spec/spi/openapi_tax.yml
@@ -82,6 +82,9 @@ paths:
       summary: Estimate tax
       description: "This endpoint is used to estimate taxes for a set of line items being sold by the Merchant to a Customer."
       operationId: estimateTaxes
+      parameters:
+        - $ref: './schemas/headers.yml#/components/parameters/MerchantId'
+        - $ref: './schemas/headers.yml#/components/parameters/TraceId'
       requestBody:
         content:
           application/json:
@@ -135,6 +138,9 @@ paths:
       summary: Create Invoice
       description: "This endpoint is used to send an invoice to the Tax Service Provider. Invoices created in Chargebee are statements of amounts owed by the Customer to the Merchant for a specific purchase."
       operationId: createInvoice
+      parameters:
+        - $ref: './schemas/headers.yml#/components/parameters/MerchantId'
+        - $ref: './schemas/headers.yml#/components/parameters/TraceId'
       requestBody:
         content:
           application/json:
@@ -180,6 +186,8 @@ paths:
       operationId: fetchInvoice
       parameters:
         - $ref: '#/components/parameters/InvoiceIdPathParam'
+        - $ref: './schemas/headers.yml#/components/parameters/MerchantId'
+        - $ref: './schemas/headers.yml#/components/parameters/TraceId'
       responses:
         '200':
           description: "Invoice retrieved successfully."
@@ -208,6 +216,8 @@ paths:
       operationId: commitInvoice
       parameters:
         - $ref: '#/components/parameters/InvoiceIdPathParam'
+        - $ref: './schemas/headers.yml#/components/parameters/MerchantId'
+        - $ref: './schemas/headers.yml#/components/parameters/TraceId'
       responses:
         '204':
           description: "Invoice committed successfully."
@@ -232,6 +242,8 @@ paths:
       operationId: voidInvoice
       parameters:
         - $ref: '#/components/parameters/InvoiceIdPathParam'
+        - $ref: './schemas/headers.yml#/components/parameters/MerchantId'
+        - $ref: './schemas/headers.yml#/components/parameters/TraceId'
       responses:
         '204':
           description: Invoice voided successfully.
@@ -254,6 +266,9 @@ paths:
       summary: "Create credit note"
       description: "This endpoint is used to send a credit note to the Tax Service Adapter. A credit note is used to reduce the amount due on an invoice. If the credit note is issued after payments have been made for the invoice, refunds can be issued to the Customer."
       operationId: createCreditNote
+      parameters:
+        - $ref: './schemas/headers.yml#/components/parameters/MerchantId'
+        - $ref: './schemas/headers.yml#/components/parameters/TraceId'
       requestBody:
         content:
           application/json:
@@ -298,6 +313,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/CreditNoteIdPathParam'
         - $ref: '#/components/parameters/InvoiceIdQueryParam'
+        - $ref: './schemas/headers.yml#/components/parameters/MerchantId'
+        - $ref: './schemas/headers.yml#/components/parameters/TraceId'
       responses:
         '200':
           description: "Credit note retrieved successfully."
@@ -327,6 +344,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/CreditNoteIdPathParam'
         - $ref: '#/components/parameters/InvoiceIdQueryParam'
+        - $ref: './schemas/headers.yml#/components/parameters/MerchantId'
+        - $ref: './schemas/headers.yml#/components/parameters/TraceId'
       responses:
         '204':
           description: Credit note committed successfully.
@@ -352,6 +371,8 @@ paths:
       parameters:
         - $ref: '#/components/parameters/CreditNoteIdPathParam'
         - $ref: '#/components/parameters/InvoiceIdQueryParam'
+        - $ref: './schemas/headers.yml#/components/parameters/MerchantId'
+        - $ref: './schemas/headers.yml#/components/parameters/TraceId'
       responses:
         '204':
           description: "Credit note voided successfully."
@@ -374,6 +395,9 @@ paths:
       operationId: validateAddress
       tags:
         - Address
+      parameters:
+        - $ref: './schemas/headers.yml#/components/parameters/MerchantId'
+        - $ref: './schemas/headers.yml#/components/parameters/TraceId'
       requestBody:
         content:
           application/json:
@@ -424,6 +448,9 @@ paths:
       operationId: checkAddressTaxability
       tags:
         - Address
+      parameters:
+        - $ref: './schemas/headers.yml#/components/parameters/MerchantId'
+        - $ref: './schemas/headers.yml#/components/parameters/TraceId'
       requestBody:
         content:
           application/json:
@@ -484,6 +511,9 @@ paths:
         '503':
           $ref: './schemas/errors.yml#/components/responses/Error503'
 components:
+  securitySchemes:
+    Authorization:
+      $ref: './schemas/headers.yml#/components/securitySchemes/Authorization'
   schemas:
     TaxEstimationRequest:
       type: object
@@ -2617,15 +2647,5 @@ components:
         code: INVALID_REQUEST
         message: Invalid Merchant id.
         detail: Please provide a valid merchant id.
-  securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-    apiKey:
-      type: apiKey
-      description: Bearer token based authentication.
-      name: bearer
-      in: header
 security:
-  - bearerAuth: []
-  - apiKey: [] 
+  - Authorization: []

--- a/spec/spi/openapi_trn.yml
+++ b/spec/spi/openapi_trn.yml
@@ -240,6 +240,9 @@ paths:
         '503':
           $ref: './schemas/errors.yml#/components/responses/Error503'
 components:
+  securitySchemes:
+    Authorization:
+      $ref: './schemas/headers.yml#/components/securitySchemes/Authorization'
   schemas:
     TrnValidateRequest:
       type: object
@@ -527,16 +530,5 @@ components:
       value:
         batchId: qwerty12345
         message: successfully deleted
-
-  securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-    apiKey:
-      type: apiKey
-      description: Bearer token based authentication.
-      name: bearer
-      in: header
 security:
-  - bearerAuth: []
-  - apiKey: [] 
+  - Authorization: []

--- a/spec/spi/paths/credentials.yml
+++ b/spec/spi/paths/credentials.yml
@@ -4,6 +4,9 @@ post:
   operationId: validateCredentials
   tags:
     - Authentication
+  parameters:
+    - $ref: '../schemas/headers.yml#/components/parameters/MerchantId'
+    - $ref: '../schemas/headers.yml#/components/parameters/TraceId'
   responses:
     '200':
       description: Authentication succeeded.

--- a/spec/spi/paths/health.yml
+++ b/spec/spi/paths/health.yml
@@ -5,8 +5,9 @@ get:
   tags:
     - Health
   # NOTE: No security scheme for the health endpoint.
-  security:
-    - { }
+  parameters:
+    - $ref: '../schemas/headers.yml#/components/parameters/MerchantId'
+    - $ref: '../schemas/headers.yml#/components/parameters/TraceId'
   responses:
     '200':
       description: Service is healthy.

--- a/spec/spi/schemas/headers.yml
+++ b/spec/spi/schemas/headers.yml
@@ -1,0 +1,22 @@
+components:
+  parameters:
+    TraceId:
+      in: header
+      name: trace_id
+      required: false
+      description: Unique id of the request will be sent by Chargebee
+      schema:
+        type: string
+    MerchantId:
+      in: header
+      name: merchant_id
+      required: false
+      description: Merchant's domain name will be sent by Chargebee
+      schema:
+        type: string
+  securitySchemes:
+    Authorization:
+      type: apiKey
+      in: header
+      name: Authorization
+      description: The json of all the parameters specified in authentication configuration of tax app will be sent by Chargebee.


### PR DESCRIPTION
Added generic headers open api yml file for common headers used in all api endpoints. 
Defined the auth schema we follow in api and used in all endpoints via global settings.

Refer screenshot for the change : https://mychargebee.atlassian.net/browse/TAXENGG-2951