### PR TITLE
TAXENGG-3818 (refactor): E-invoicing country - simple configuration support

### DIFF
--- a/spec/capabilities/einvoicing-provider.schema.json
+++ b/spec/capabilities/einvoicing-provider.schema.json
@@ -156,9 +156,7 @@
       },
       "required": [
         "api_base_url",
-        "credential_configuration",
-        "chargebee_oauth",
-        "webhook_configuration"
+        "credential_configuration"
       ],
       "examples": [
         {
@@ -312,7 +310,6 @@
         "retrieve_business_entities_supported",
         "retrieve_input_fields_supported",
         "retrieve_einvoice_status_supported",
-        "customer_identifiers",
         "document_download"
       ],
       "examples": [

--- a/spec/capabilities/einvoicing-provider.schema.json
+++ b/spec/capabilities/einvoicing-provider.schema.json
@@ -282,7 +282,11 @@
         },
         "retrieve_activation_supported": {
           "type": "boolean",
-          "description": "Specifies if retrieving merchant activation info from E-invoicing provider portal via Chargebee is supported."
+          "description": "Specifies if retrieving merchant activation info from the E-invoicing provider portal via Chargebee is supported."
+        },
+        "retrieve_business_entities_supported": {
+          "type": "boolean",
+          "description": "Specifies if retrieving the list of business entities configured in the E-invoicing provider portal via Chargebee is supported."
         },
         "retrieve_input_fields_supported": {
           "type": "boolean",
@@ -305,6 +309,7 @@
         "supported_countries",
         "supported_currencies",
         "retrieve_activation_supported",
+        "retrieve_business_entities_supported",
         "retrieve_input_fields_supported",
         "retrieve_einvoice_status_supported",
         "customer_identifiers",
@@ -319,6 +324,7 @@
                 "USD", "EUR", "GBP", "AUD", "CAD", "JPY", "INR", "CNY", "BRL", "MXN"
             ],
             "retrieve_activation_supported": true,
+            "retrieve_business_entities_supported": true,
             "retrieve_input_fields_supported": true,
             "retrieve_einvoice_status_supported": true,
             "customer_identifiers": [

--- a/spec/capabilities/einvoicing-provider.schema.json
+++ b/spec/capabilities/einvoicing-provider.schema.json
@@ -284,6 +284,10 @@
           "type": "boolean",
           "description": "Specifies if retrieving merchant activation info from E-invoicing provider portal via Chargebee is supported."
         },
+        "retrieve_input_fields_supported": {
+          "type": "boolean",
+          "description": "Specifies if retrieving data input fields from the E-invoicing provider via Chargebee is supported."
+        },
         "retrieve_einvoice_status_supported": {
           "type": "boolean",
           "description": "Specifies if fetching e-invoice status for a given invoice is supported."
@@ -301,6 +305,7 @@
         "supported_countries",
         "supported_currencies",
         "retrieve_activation_supported",
+        "retrieve_input_fields_supported",
         "retrieve_einvoice_status_supported",
         "customer_identifiers",
         "document_download"
@@ -314,6 +319,7 @@
                 "USD", "EUR", "GBP", "AUD", "CAD", "JPY", "INR", "CNY", "BRL", "MXN"
             ],
             "retrieve_activation_supported": true,
+            "retrieve_input_fields_supported": true,
             "retrieve_einvoice_status_supported": true,
             "customer_identifiers": [
                 {

--- a/spec/spi/generated/einvoicing/api/openapi.yaml
+++ b/spec/spi/generated/einvoicing/api/openapi.yaml
@@ -335,12 +335,41 @@ paths:
           example: B2B
           type: string
         style: form
-      - explode: true
+      - description: "Indicates the eInvoicing flow model that governs the document\
+          \ exchange and processing mechanism. \nDifferent countries adopt different\
+          \ models based on legal, technical, and administrative mandates.\nSupported\
+          \ values:\n- PEPPOL: A standardized, secure eInvoicing network enabling\
+          \ cross-border electronic document exchange between businesses and governments.\n\
+          - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged\
+          \ between businesses and sometimes stored.\n- CLEARANCE: Invoices must be\
+          \ pre-approved by a tax authority before they are sent to the buyer.\n-\
+          \ REPORTING: Invoices are shared with tax authorities after issuance, usually\
+          \ for compliance and audit purposes.\n- ZUGFERD: A hybrid eInvoicing format\
+          \ used in Germany combining PDF and XML for human and machine readability.\n\
+          - CTC: Continuous Transaction Controls involve real-time or near-real-time\
+          \ invoice validation and transmission to tax authorities.\n- NEMHANDEL:\
+          \ Denmark’s national infrastructure for eInvoicing that supports secure\
+          \ delivery via specific formats like OIOUBL.\n- FACE: Spain’s centralized\
+          \ system (FACe/FACeB2B) for routing invoices to government or private recipients.\n\
+          - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices\
+          \ directly to the tax agency.\n"
+        explode: true
         in: query
         name: model
         required: true
         schema:
-          $ref: '#/components/schemas/model'
+          enum:
+          - PEPPOL
+          - EINVOICE
+          - CLEARANCE
+          - REPORTING
+          - ZUGFERD
+          - CTC
+          - NEMHANDEL
+          - FACE
+          - VERIFACTU
+          example: PEPPOL
+          type: string
         style: form
       - description: Type of business document.
         explode: true
@@ -1326,12 +1355,41 @@ paths:
           example: B2B
           type: string
         style: form
-      - explode: true
+      - description: "Indicates the eInvoicing flow model that governs the document\
+          \ exchange and processing mechanism. \nDifferent countries adopt different\
+          \ models based on legal, technical, and administrative mandates.\nSupported\
+          \ values:\n- PEPPOL: A standardized, secure eInvoicing network enabling\
+          \ cross-border electronic document exchange between businesses and governments.\n\
+          - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged\
+          \ between businesses and sometimes stored.\n- CLEARANCE: Invoices must be\
+          \ pre-approved by a tax authority before they are sent to the buyer.\n-\
+          \ REPORTING: Invoices are shared with tax authorities after issuance, usually\
+          \ for compliance and audit purposes.\n- ZUGFERD: A hybrid eInvoicing format\
+          \ used in Germany combining PDF and XML for human and machine readability.\n\
+          - CTC: Continuous Transaction Controls involve real-time or near-real-time\
+          \ invoice validation and transmission to tax authorities.\n- NEMHANDEL:\
+          \ Denmark’s national infrastructure for eInvoicing that supports secure\
+          \ delivery via specific formats like OIOUBL.\n- FACE: Spain’s centralized\
+          \ system (FACe/FACeB2B) for routing invoices to government or private recipients.\n\
+          - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices\
+          \ directly to the tax agency.\n"
+        explode: true
         in: query
         name: model
         required: true
         schema:
-          $ref: '#/components/schemas/model'
+          enum:
+          - PEPPOL
+          - EINVOICE
+          - CLEARANCE
+          - REPORTING
+          - ZUGFERD
+          - CTC
+          - NEMHANDEL
+          - FACE
+          - VERIFACTU
+          example: PEPPOL
+          type: string
         style: form
       - description: Type of business document.
         explode: true

--- a/spec/spi/generated/einvoicing/api/openapi.yaml
+++ b/spec/spi/generated/einvoicing/api/openapi.yaml
@@ -335,41 +335,12 @@ paths:
           example: B2B
           type: string
         style: form
-      - description: "Indicates the eInvoicing flow model that governs the document\
-          \ exchange and processing mechanism. \nDifferent countries adopt different\
-          \ models based on legal, technical, and administrative mandates.\nSupported\
-          \ values:\n- PEPPOL: A standardized, secure eInvoicing network enabling\
-          \ cross-border electronic document exchange between businesses and governments.\n\
-          - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged\
-          \ between businesses and sometimes stored.\n- CLEARANCE: Invoices must be\
-          \ pre-approved by a tax authority before they are sent to the buyer.\n-\
-          \ REPORTING: Invoices are shared with tax authorities after issuance, usually\
-          \ for compliance and audit purposes.\n- ZUGFERD: A hybrid eInvoicing format\
-          \ used in Germany combining PDF and XML for human and machine readability.\n\
-          - CTC: Continuous Transaction Controls involve real-time or near-real-time\
-          \ invoice validation and transmission to tax authorities.\n- NEMHANDEL:\
-          \ Denmark’s national infrastructure for eInvoicing that supports secure\
-          \ delivery via specific formats like OIOUBL.\n- FACE: Spain’s centralized\
-          \ system (FACe/FACeB2B) for routing invoices to government or private recipients.\n\
-          - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices\
-          \ directly to the tax agency.\n"
-        explode: true
+      - explode: true
         in: query
         name: model
         required: true
         schema:
-          enum:
-          - PEPPOL
-          - EINVOICE
-          - CLEARANCE
-          - REPORTING
-          - ZUGFERD
-          - CTC
-          - NEMHANDEL
-          - FACE
-          - VERIFACTU
-          example: PEPPOL
-          type: string
+          $ref: '#/components/schemas/model'
         style: form
       - description: Type of business document.
         explode: true
@@ -1355,41 +1326,12 @@ paths:
           example: B2B
           type: string
         style: form
-      - description: "Indicates the eInvoicing flow model that governs the document\
-          \ exchange and processing mechanism. \nDifferent countries adopt different\
-          \ models based on legal, technical, and administrative mandates.\nSupported\
-          \ values:\n- PEPPOL: A standardized, secure eInvoicing network enabling\
-          \ cross-border electronic document exchange between businesses and governments.\n\
-          - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged\
-          \ between businesses and sometimes stored.\n- CLEARANCE: Invoices must be\
-          \ pre-approved by a tax authority before they are sent to the buyer.\n-\
-          \ REPORTING: Invoices are shared with tax authorities after issuance, usually\
-          \ for compliance and audit purposes.\n- ZUGFERD: A hybrid eInvoicing format\
-          \ used in Germany combining PDF and XML for human and machine readability.\n\
-          - CTC: Continuous Transaction Controls involve real-time or near-real-time\
-          \ invoice validation and transmission to tax authorities.\n- NEMHANDEL:\
-          \ Denmark’s national infrastructure for eInvoicing that supports secure\
-          \ delivery via specific formats like OIOUBL.\n- FACE: Spain’s centralized\
-          \ system (FACe/FACeB2B) for routing invoices to government or private recipients.\n\
-          - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices\
-          \ directly to the tax agency.\n"
-        explode: true
+      - explode: true
         in: query
         name: model
         required: true
         schema:
-          enum:
-          - PEPPOL
-          - EINVOICE
-          - CLEARANCE
-          - REPORTING
-          - ZUGFERD
-          - CTC
-          - NEMHANDEL
-          - FACE
-          - VERIFACTU
-          example: PEPPOL
-          type: string
+          $ref: '#/components/schemas/model'
         style: form
       - description: Type of business document.
         explode: true
@@ -1731,6 +1673,32 @@ components:
             $ref: '#/components/schemas/HealthCheckResponse'
       description: Service is unhealthy.
   schemas:
+    model:
+      description: |
+        Indicates the eInvoicing flow model that governs the document exchange and processing mechanism.
+        Different countries adopt different models based on legal, technical, and administrative mandates.
+        Supported values:
+        - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
+        - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
+        - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
+        - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
+        - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
+        - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
+        - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
+        - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
+        - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
+      enum:
+      - PEPPOL
+      - EINVOICE
+      - CLEARANCE
+      - REPORTING
+      - ZUGFERD
+      - CTC
+      - NEMHANDEL
+      - FACE
+      - VERIFACTU
+      example: PEPPOL
+      type: string
     activation:
       properties:
         id:
@@ -1748,36 +1716,7 @@ components:
     country_activation:
       properties:
         model:
-          description: "Indicates the eInvoicing flow model that governs the document\
-            \ exchange and processing mechanism. \nDifferent countries adopt different\
-            \ models based on legal, technical, and administrative mandates.\nSupported\
-            \ values:\n- PEPPOL: A standardized, secure eInvoicing network enabling\
-            \ cross-border electronic document exchange between businesses and governments.\n\
-            - EINVOICE: Traditional eInvoicing model where invoices are digitally\
-            \ exchanged between businesses and sometimes stored.\n- CLEARANCE: Invoices\
-            \ must be pre-approved by a tax authority before they are sent to the\
-            \ buyer.\n- REPORTING: Invoices are shared with tax authorities after\
-            \ issuance, usually for compliance and audit purposes.\n- ZUGFERD: A hybrid\
-            \ eInvoicing format used in Germany combining PDF and XML for human and\
-            \ machine readability.\n- CTC: Continuous Transaction Controls involve\
-            \ real-time or near-real-time invoice validation and transmission to tax\
-            \ authorities.\n- NEMHANDEL: Denmark’s national infrastructure for eInvoicing\
-            \ that supports secure delivery via specific formats like OIOUBL.\n- FACE:\
-            \ Spain’s centralized system (FACe/FACeB2B) for routing invoices to government\
-            \ or private recipients.\n- VERIFACTU: Spain’s mechanism for validating\
-            \ and reporting sales invoices directly to the tax agency.\n"
-          enum:
-          - PEPPOL
-          - EINVOICE
-          - CLEARANCE
-          - REPORTING
-          - ZUGFERD
-          - CTC
-          - NEMHANDEL
-          - FACE
-          - VERIFACTU
-          example: PEPPOL
-          type: string
+          $ref: '#/components/schemas/model'
         country:
           description: ISO 3166-1 alpha-2 country code where the e-invoicing activation
             is applicable.
@@ -1877,36 +1816,7 @@ components:
           example: B2B
           type: string
         model:
-          description: "Indicates the eInvoicing flow model that governs the document\
-            \ exchange and processing mechanism. \nDifferent countries adopt different\
-            \ models based on legal, technical, and administrative mandates.\nSupported\
-            \ values:\n- PEPPOL: A standardized, secure eInvoicing network enabling\
-            \ cross-border electronic document exchange between businesses and governments.\n\
-            - EINVOICE: Traditional eInvoicing model where invoices are digitally\
-            \ exchanged between businesses and sometimes stored.\n- CLEARANCE: Invoices\
-            \ must be pre-approved by a tax authority before they are sent to the\
-            \ buyer.\n- REPORTING: Invoices are shared with tax authorities after\
-            \ issuance, usually for compliance and audit purposes.\n- ZUGFERD: A hybrid\
-            \ eInvoicing format used in Germany combining PDF and XML for human and\
-            \ machine readability.\n- CTC: Continuous Transaction Controls involve\
-            \ real-time or near-real-time invoice validation and transmission to tax\
-            \ authorities.\n- NEMHANDEL: Denmark’s national infrastructure for eInvoicing\
-            \ that supports secure delivery via specific formats like OIOUBL.\n- FACE:\
-            \ Spain’s centralized system (FACe/FACeB2B) for routing invoices to government\
-            \ or private recipients.\n- VERIFACTU: Spain’s mechanism for validating\
-            \ and reporting sales invoices directly to the tax agency.\n"
-          enum:
-          - PEPPOL
-          - EINVOICE
-          - CLEARANCE
-          - REPORTING
-          - ZUGFERD
-          - CTC
-          - NEMHANDEL
-          - FACE
-          - VERIFACTU
-          example: PEPPOL
-          type: string
+          $ref: '#/components/schemas/model'
         document_type:
           description: Type of business document.
           example: ubl-invoice
@@ -1956,36 +1866,7 @@ components:
           example: B2B
           type: string
         model:
-          description: "Indicates the eInvoicing flow model that governs the document\
-            \ exchange and processing mechanism. \nDifferent countries adopt different\
-            \ models based on legal, technical, and administrative mandates.\nSupported\
-            \ values:\n- PEPPOL: A standardized, secure eInvoicing network enabling\
-            \ cross-border electronic document exchange between businesses and governments.\n\
-            - EINVOICE: Traditional eInvoicing model where invoices are digitally\
-            \ exchanged between businesses and sometimes stored.\n- CLEARANCE: Invoices\
-            \ must be pre-approved by a tax authority before they are sent to the\
-            \ buyer.\n- REPORTING: Invoices are shared with tax authorities after\
-            \ issuance, usually for compliance and audit purposes.\n- ZUGFERD: A hybrid\
-            \ eInvoicing format used in Germany combining PDF and XML for human and\
-            \ machine readability.\n- CTC: Continuous Transaction Controls involve\
-            \ real-time or near-real-time invoice validation and transmission to tax\
-            \ authorities.\n- NEMHANDEL: Denmark’s national infrastructure for eInvoicing\
-            \ that supports secure delivery via specific formats like OIOUBL.\n- FACE:\
-            \ Spain’s centralized system (FACe/FACeB2B) for routing invoices to government\
-            \ or private recipients.\n- VERIFACTU: Spain’s mechanism for validating\
-            \ and reporting sales invoices directly to the tax agency.\n"
-          enum:
-          - PEPPOL
-          - EINVOICE
-          - CLEARANCE
-          - REPORTING
-          - ZUGFERD
-          - CTC
-          - NEMHANDEL
-          - FACE
-          - VERIFACTU
-          example: PEPPOL
-          type: string
+          $ref: '#/components/schemas/model'
         document_type:
           description: Type of business document.
           example: ubl-invoice
@@ -2081,36 +1962,7 @@ components:
           example: B2B
           type: string
         model:
-          description: "Indicates the eInvoicing flow model that governs the document\
-            \ exchange and processing mechanism. \nDifferent countries adopt different\
-            \ models based on legal, technical, and administrative mandates.\nSupported\
-            \ values:\n- PEPPOL: A standardized, secure eInvoicing network enabling\
-            \ cross-border electronic document exchange between businesses and governments.\n\
-            - EINVOICE: Traditional eInvoicing model where invoices are digitally\
-            \ exchanged between businesses and sometimes stored.\n- CLEARANCE: Invoices\
-            \ must be pre-approved by a tax authority before they are sent to the\
-            \ buyer.\n- REPORTING: Invoices are shared with tax authorities after\
-            \ issuance, usually for compliance and audit purposes.\n- ZUGFERD: A hybrid\
-            \ eInvoicing format used in Germany combining PDF and XML for human and\
-            \ machine readability.\n- CTC: Continuous Transaction Controls involve\
-            \ real-time or near-real-time invoice validation and transmission to tax\
-            \ authorities.\n- NEMHANDEL: Denmark’s national infrastructure for eInvoicing\
-            \ that supports secure delivery via specific formats like OIOUBL.\n- FACE:\
-            \ Spain’s centralized system (FACe/FACeB2B) for routing invoices to government\
-            \ or private recipients.\n- VERIFACTU: Spain’s mechanism for validating\
-            \ and reporting sales invoices directly to the tax agency.\n"
-          enum:
-          - PEPPOL
-          - EINVOICE
-          - CLEARANCE
-          - REPORTING
-          - ZUGFERD
-          - CTC
-          - NEMHANDEL
-          - FACE
-          - VERIFACTU
-          example: PEPPOL
-          type: string
+          $ref: '#/components/schemas/model'
         document_type:
           description: Type of business document.
           example: ubl-applicationresponse
@@ -2194,36 +2046,7 @@ components:
           example: B2B
           type: string
         model:
-          description: "Indicates the eInvoicing flow model that governs the document\
-            \ exchange and processing mechanism. \nDifferent countries adopt different\
-            \ models based on legal, technical, and administrative mandates.\nSupported\
-            \ values:\n- PEPPOL: A standardized, secure eInvoicing network enabling\
-            \ cross-border electronic document exchange between businesses and governments.\n\
-            - EINVOICE: Traditional eInvoicing model where invoices are digitally\
-            \ exchanged between businesses and sometimes stored.\n- CLEARANCE: Invoices\
-            \ must be pre-approved by a tax authority before they are sent to the\
-            \ buyer.\n- REPORTING: Invoices are shared with tax authorities after\
-            \ issuance, usually for compliance and audit purposes.\n- ZUGFERD: A hybrid\
-            \ eInvoicing format used in Germany combining PDF and XML for human and\
-            \ machine readability.\n- CTC: Continuous Transaction Controls involve\
-            \ real-time or near-real-time invoice validation and transmission to tax\
-            \ authorities.\n- NEMHANDEL: Denmark’s national infrastructure for eInvoicing\
-            \ that supports secure delivery via specific formats like OIOUBL.\n- FACE:\
-            \ Spain’s centralized system (FACe/FACeB2B) for routing invoices to government\
-            \ or private recipients.\n- VERIFACTU: Spain’s mechanism for validating\
-            \ and reporting sales invoices directly to the tax agency.\n"
-          enum:
-          - PEPPOL
-          - EINVOICE
-          - CLEARANCE
-          - REPORTING
-          - ZUGFERD
-          - CTC
-          - NEMHANDEL
-          - FACE
-          - VERIFACTU
-          example: PEPPOL
-          type: string
+          $ref: '#/components/schemas/model'
         document_type:
           description: Type of business document.
           example: ubl-invoice
@@ -2376,28 +2199,7 @@ components:
             $ref: '#/components/schemas/download_document_response_documents_inner'
           type: array
         model:
-          description: "Indicates the eInvoicing flow model that governs the document\
-            \ exchange and processing mechanism. \nDifferent countries adopt different\
-            \ models based on legal, technical, and administrative mandates.\nSupported\
-            \ values:\n  - PEPPOL: A standardized, secure eInvoicing network enabling\
-            \ cross-border electronic document exchange between businesses and governments.\n\
-            \  - EINVOICE: Traditional eInvoicing model where invoices are digitally\
-            \ exchanged between businesses and sometimes stored.\n  - CLEARANCE: Invoices\
-            \ must be pre-approved by a tax authority before they are sent to the\
-            \ buyer.\n  - REPORTING: Invoices are shared with tax authorities after\
-            \ issuance, usually for compliance and audit purposes.\n  - ZUGFERD: A\
-            \ hybrid eInvoicing format used in Germany combining PDF and XML for human\
-            \ and machine readability.\n  - CTC: Continuous Transaction Controls involve\
-            \ real-time or near-real-time invoice validation and transmission to tax\
-            \ authorities.\n  - NEMHANDEL: Denmark’s national infrastructure for eInvoicing\
-            \ that supports secure delivery via specific formats like OIOUBL.\n  -\
-            \ FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices\
-            \ to government or private recipients.\n  - VERIFACTU: Spain’s mechanism\
-            \ for validating and reporting sales invoices directly to the tax agency.\n\
-            \  schema:\n    type: string\n    enum:\n      - PEPPOL\n      - EINVOICE\n\
-            \      - CLEARANCE\n      - REPORTING\n      - ZUGFERD\n      - CTC\n\
-            \      - NEMHANDEL\n      - FACE\n      - VERIFACTU\n    example: \"PEPPOL\"\
-            \n"
+          $ref: '#/components/schemas/model'
       required:
       - document_id
       - documents

--- a/spec/spi/generated/einvoicing/api/openapi.yaml
+++ b/spec/spi/generated/einvoicing/api/openapi.yaml
@@ -505,6 +505,9 @@ paths:
             --data '{
               "id": "INV-10001",
               "type": "INVOICE",
+              "country": "DE",
+              "transaction_type": "B2B",
+              "model": "PEPPOL",
               "issue_date": "2025-04-02",
               "tax_date": "2025-04-02",
               "currency_code": "EUR",
@@ -589,45 +592,46 @@ paths:
         source: "curl --request POST \\\n  --url https://partner.app.com/einvoicing/documents\
           \ \\\n  --header 'Content-Type: application/json' \\\n  --header 'Authorization:\
           \ {\"api_key\" : ... }' \\\n  --data '{\n    \"id\": \"INV-20221607\",\n\
-          \    \"type\": \"INVOICE\",\n    \"issue_date\": \"2025-04-02\",\n    \"\
-          tax_date\": \"2025-04-02\",\n    \"currency_code\": \"EUR\",\n    \"due_date\"\
-          : \"2025-04-30\",\n    \"amount\": 114.0,\n    \"note\": \"Payment due in\
-          \ 28 days.\",\n    \"accounting_supplier_party\": {\n      \"name\": \"\
-          Example Seller GmbH\",\n      \"address\": {\n        \"line_1\": \"Hauptstr.\
-          \ 456\",\n        \"line_2\": \"Suite 5\",\n        \"zip\": \"50667\",\n\
-          \        \"city\": \"Cologne\",\n        \"country\": \"DE\"\n      },\n\
-          \      \"tax_scheme\": [\n        {\n          \"scheme\": \"VAT\",\n  \
-          \        \"id\": \"DE987654321\"\n        }\n      ]\n    },\n    \"accounting_customer_party\"\
-          : {\n      \"name\": \"Example Buyer GmbH\",\n      \"address\": {\n   \
-          \     \"line_1\": \"Berliner Str. 123\",\n        \"line_2\": \"2nd Floor\"\
-          ,\n        \"zip\": \"10115\",\n        \"city\": \"Berlin\",\n        \"\
-          country\": \"DE\"\n      },\n      \"tax_scheme\": [\n        {\n      \
-          \    \"scheme\": \"VAT\",\n          \"id\": \"DE123456789\"\n        }\n\
-          \      ]\n    },\n    \"payment_means\": [\n      {\n        \"code\": \"\
-          ONLINE_PAYMENT_SERVICE\",\n        \"payment_id\": \"PAY-2024-00987\",\n\
-          \        \"card_account\": {\n          \"primary_account_number_id\": \"\
-          4111********1111\",\n          \"card_holder_name\": \"Jane Smith\",\n \
-          \         \"network_id\": \"MASTERCARD\"\n        }\n      }\n    ],\n \
-          \   \"lines\": [\n      {\n        \"id\": \"1\",\n        \"description\"\
-          : \"Consulting Services - April\",\n        \"quantity\": 1,\n        \"\
-          unit_price\": 100.0,\n        \"amount\": 100.0,\n        \"item_code\"\
-          : \"CONS-APRIL\",\n        \"classified_tax_category\": [\n          {\n\
-          \            \"percentage\": 14,\n            \"category\": \"VAT\",\n \
-          \           \"country\": \"DE\"\n          }\n        ]\n      }\n    ],\n\
-          \    \"tax_total\": {\n      \"tax_amount\": 14.0,\n      \"tax_sub_totals\"\
-          : [\n        {\n          \"taxable_amount\": 100.0,\n          \"tax_amount\"\
-          : 14.0,\n          \"percentage\": 14,\n          \"country\": \"DE\",\n\
-          \          \"category\": \"VAT\"\n        }\n      ]\n    },\n    \"overrides\"\
-          : {\n      \"country\": \"DE\", \n      \"transaction_type\": \"B2B\",\n\
-          \      \"model\": \"PEPPOL\",\n      \"document_type\": \"ubl-invoice\"\
-          ,\n      \"field_mapping\": [\n        {\n          \"target\": \"Invoice.cbc:ID\"\
-          ,\n          \"source\": \"invoice.id\"\n        },\n        {\n       \
-          \   \"target\": \"Invoice.cbc:IssueDate\",\n          \"source\": \"invoice.issue_date\"\
-          \n        },\n        {\n          \"target\": \"Invoice.cbc:InvoiceTypeCode\"\
-          ,\n          \"fixed_value\": \"380\"\n        },\n        {\n         \
-          \ \"target\": \"Invoice.cbc:DocumentCurrencyCode\",\n          \"source\"\
-          : \"invoice.currency_code\"\n        },\n        {\n          \"target\"\
-          : \"Invoice.cac:AccountingSupplierParty.cac:Party.cac:PostalAddress.cac:Country.cbc:IdentificationCode\"\
+          \    \"type\": \"INVOICE\",\n    \"country\": \"DE\",\n    \"transaction_type\"\
+          : \"B2B\",\n    \"model\": \"PEPPOL\",\n    \"issue_date\": \"2025-04-02\"\
+          ,\n    \"tax_date\": \"2025-04-02\",\n    \"currency_code\": \"EUR\",\n\
+          \    \"due_date\": \"2025-04-30\",\n    \"amount\": 114.0,\n    \"note\"\
+          : \"Payment due in 28 days.\",\n    \"accounting_supplier_party\": {\n \
+          \     \"name\": \"Example Seller GmbH\",\n      \"address\": {\n       \
+          \ \"line_1\": \"Hauptstr. 456\",\n        \"line_2\": \"Suite 5\",\n   \
+          \     \"zip\": \"50667\",\n        \"city\": \"Cologne\",\n        \"country\"\
+          : \"DE\"\n      },\n      \"tax_scheme\": [\n        {\n          \"scheme\"\
+          : \"VAT\",\n          \"id\": \"DE987654321\"\n        }\n      ]\n    },\n\
+          \    \"accounting_customer_party\": {\n      \"name\": \"Example Buyer GmbH\"\
+          ,\n      \"address\": {\n        \"line_1\": \"Berliner Str. 123\",\n  \
+          \      \"line_2\": \"2nd Floor\",\n        \"zip\": \"10115\",\n       \
+          \ \"city\": \"Berlin\",\n        \"country\": \"DE\"\n      },\n      \"\
+          tax_scheme\": [\n        {\n          \"scheme\": \"VAT\",\n          \"\
+          id\": \"DE123456789\"\n        }\n      ]\n    },\n    \"payment_means\"\
+          : [\n      {\n        \"code\": \"ONLINE_PAYMENT_SERVICE\",\n        \"\
+          payment_id\": \"PAY-2024-00987\",\n        \"card_account\": {\n       \
+          \   \"primary_account_number_id\": \"4111********1111\",\n          \"card_holder_name\"\
+          : \"Jane Smith\",\n          \"network_id\": \"MASTERCARD\"\n        }\n\
+          \      }\n    ],\n    \"lines\": [\n      {\n        \"id\": \"1\",\n  \
+          \      \"description\": \"Consulting Services - April\",\n        \"quantity\"\
+          : 1,\n        \"unit_price\": 100.0,\n        \"amount\": 100.0,\n     \
+          \   \"item_code\": \"CONS-APRIL\",\n        \"classified_tax_category\"\
+          : [\n          {\n            \"percentage\": 14,\n            \"category\"\
+          : \"VAT\",\n            \"country\": \"DE\"\n          }\n        ]\n  \
+          \    }\n    ],\n    \"tax_total\": {\n      \"tax_amount\": 14.0,\n    \
+          \  \"tax_sub_totals\": [\n        {\n          \"taxable_amount\": 100.0,\n\
+          \          \"tax_amount\": 14.0,\n          \"percentage\": 14,\n      \
+          \    \"country\": \"DE\",\n          \"category\": \"VAT\"\n        }\n\
+          \      ]\n    },\n    \"overrides\": {\n      \"country\": \"DE\", \n  \
+          \    \"transaction_type\": \"B2B\",\n      \"model\": \"PEPPOL\",\n    \
+          \  \"document_type\": \"ubl-invoice\",\n      \"field_mapping\": [\n   \
+          \     {\n          \"target\": \"Invoice.cbc:ID\",\n          \"source\"\
+          : \"invoice.id\"\n        },\n        {\n          \"target\": \"Invoice.cbc:IssueDate\"\
+          ,\n          \"source\": \"invoice.issue_date\"\n        },\n        {\n\
+          \          \"target\": \"Invoice.cbc:InvoiceTypeCode\",\n          \"fixed_value\"\
+          : \"380\"\n        },\n        {\n          \"target\": \"Invoice.cbc:DocumentCurrencyCode\"\
+          ,\n          \"source\": \"invoice.currency_code\"\n        },\n       \
+          \ {\n          \"target\": \"Invoice.cac:AccountingSupplierParty.cac:Party.cac:PostalAddress.cac:Country.cbc:IdentificationCode\"\
           ,\n          \"source\": \"business.address.country\"\n        },\n    \
           \    {\n          \"target\": \"Invoice.cac:AccountingCustomerParty.cac:Party.cac:PostalAddress.cac:Country.cbc:IdentificationCode\"\
           ,\n          \"source\": \"customer.billing_address.country\"\n        },\n\
@@ -693,6 +697,9 @@ paths:
             --data '{
               "id": "CN-20002",
               "type": "CREDIT_NOTE",
+              "country": "DE",
+              "transaction_type": "B2B",
+              "model": "PEPPOL",
               "issue_date": "2025-04-10",
               "tax_date": "2025-04-10",
               "currency_code": "EUR",
@@ -780,16 +787,17 @@ paths:
         source: "curl --request POST \\\n  --url https://partner.app.com/einvoicing/documents\
           \ \\\n  --header 'Content-Type: application/json' \\\n  --header 'Authorization:\
           \ {\"api_key\" : ... }' \\\n  --data '{\n    \"id\": \"CN-20002\",\n   \
-          \ \"type\": \"CREDIT_NOTE\",\n    \"issue_date\": \"2025-04-10\",\n    \"\
-          tax_date\": \"2025-04-10\",\n    \"currency_code\": \"EUR\",\n    \"due_date\"\
-          : \"2025-04-30\",\n    \"amount\": 50.0,\n    \"note\": \"Credit issued\
-          \ for April billing adjustment.\",\n    \"billing_reference\": [\n     \
-          \ \"INV-10001\"\n    ],\n    \"accounting_supplier_party\": {\n      \"\
-          name\": \"Example Seller GmbH\",\n      \"address\": {\n        \"line_1\"\
-          : \"Hauptstr. 456\",\n        \"line_2\": \"Suite 5\",\n        \"zip\"\
-          : \"50667\",\n        \"city\": \"Cologne\",\n        \"country\": \"DE\"\
-          \n      },\n      \"tax_scheme\": [\n        {\n          \"scheme\": \"\
-          VAT\",\n          \"id\": \"DE987654321\"\n        }\n      ]\n    },\n\
+          \ \"type\": \"CREDIT_NOTE\",\n    \"country\": \"DE\",\n    \"transaction_type\"\
+          : \"B2B\",\n    \"model\": \"PEPPOL\",\n    \"issue_date\": \"2025-04-10\"\
+          ,\n    \"tax_date\": \"2025-04-10\",\n    \"currency_code\": \"EUR\",\n\
+          \    \"due_date\": \"2025-04-30\",\n    \"amount\": 50.0,\n    \"note\"\
+          : \"Credit issued for April billing adjustment.\",\n    \"billing_reference\"\
+          : [\n      \"INV-10001\"\n    ],\n    \"accounting_supplier_party\": {\n\
+          \      \"name\": \"Example Seller GmbH\",\n      \"address\": {\n      \
+          \  \"line_1\": \"Hauptstr. 456\",\n        \"line_2\": \"Suite 5\",\n  \
+          \      \"zip\": \"50667\",\n        \"city\": \"Cologne\",\n        \"country\"\
+          : \"DE\"\n      },\n      \"tax_scheme\": [\n        {\n          \"scheme\"\
+          : \"VAT\",\n          \"id\": \"DE987654321\"\n        }\n      ]\n    },\n\
           \    \"accounting_customer_party\": {\n      \"name\": \"Example Buyer GmbH\"\
           ,\n      \"address\": {\n        \"line_1\": \"Berliner Str. 123\",\n  \
           \      \"line_2\": \"2nd Floor\",\n        \"zip\": \"10115\",\n       \
@@ -907,6 +915,9 @@ paths:
             --data '{
               "id": "APPRESP-20250402-002",
               "type": "APPLICATION_RESPONSE",
+              "country": "DE",
+              "transaction_type": "B2B",
+              "model": "PEPPOL",
               "issue_date": "2025-04-04",
               "sender_party": {
                 "legal_entity": {
@@ -940,6 +951,9 @@ paths:
             --data '{
               "id": "APPRESP-20240401-001",
               "type": "APPLICATION_RESPONSE",
+              "country": "DE",
+              "transaction_type": "B2B",
+              "model": "PEPPOL",
               "issue_date": "2025-04-03",
               "sender_party": {
                 "legal_entity": {
@@ -1925,6 +1939,49 @@ components:
           - INVOICE
           - CREDIT_NOTE
           type: string
+        country:
+          description: The ISO country code for the scenario.
+          example: DE
+          type: string
+        transaction_type:
+          description: "The type of transaction (B2B, B2C, B2G)."
+          enum:
+          - B2B
+          - B2C
+          - B2G
+          example: B2B
+          type: string
+        model:
+          description: "Indicates the eInvoicing flow model that governs the document\
+            \ exchange and processing mechanism. \nDifferent countries adopt different\
+            \ models based on legal, technical, and administrative mandates.\nSupported\
+            \ values:\n- PEPPOL: A standardized, secure eInvoicing network enabling\
+            \ cross-border electronic document exchange between businesses and governments.\n\
+            - EINVOICE: Traditional eInvoicing model where invoices are digitally\
+            \ exchanged between businesses and sometimes stored.\n- CLEARANCE: Invoices\
+            \ must be pre-approved by a tax authority before they are sent to the\
+            \ buyer.\n- REPORTING: Invoices are shared with tax authorities after\
+            \ issuance, usually for compliance and audit purposes.\n- ZUGFERD: A hybrid\
+            \ eInvoicing format used in Germany combining PDF and XML for human and\
+            \ machine readability.\n- CTC: Continuous Transaction Controls involve\
+            \ real-time or near-real-time invoice validation and transmission to tax\
+            \ authorities.\n- NEMHANDEL: Denmark’s national infrastructure for eInvoicing\
+            \ that supports secure delivery via specific formats like OIOUBL.\n- FACE:\
+            \ Spain’s centralized system (FACe/FACeB2B) for routing invoices to government\
+            \ or private recipients.\n- VERIFACTU: Spain’s mechanism for validating\
+            \ and reporting sales invoices directly to the tax agency.\n"
+          enum:
+          - PEPPOL
+          - EINVOICE
+          - CLEARANCE
+          - REPORTING
+          - ZUGFERD
+          - CTC
+          - NEMHANDEL
+          - FACE
+          - VERIFACTU
+          example: PEPPOL
+          type: string
         issue_date:
           description: The date when the document was issued. Format "YYYY-MM-DD"
           format: date
@@ -1980,6 +2037,7 @@ components:
       - accounting_customer_party
       - accounting_supplier_party
       - amount
+      - country
       - currency_code
       - dueDate
       - id
@@ -2001,6 +2059,49 @@ components:
           enum:
           - APPLICATION_RESPONSE
           type: string
+        country:
+          description: The ISO country code for the scenario.
+          example: DE
+          type: string
+        transaction_type:
+          description: "The type of transaction (B2B, B2C, B2G)."
+          enum:
+          - B2B
+          - B2C
+          - B2G
+          example: B2B
+          type: string
+        model:
+          description: "Indicates the eInvoicing flow model that governs the document\
+            \ exchange and processing mechanism. \nDifferent countries adopt different\
+            \ models based on legal, technical, and administrative mandates.\nSupported\
+            \ values:\n- PEPPOL: A standardized, secure eInvoicing network enabling\
+            \ cross-border electronic document exchange between businesses and governments.\n\
+            - EINVOICE: Traditional eInvoicing model where invoices are digitally\
+            \ exchanged between businesses and sometimes stored.\n- CLEARANCE: Invoices\
+            \ must be pre-approved by a tax authority before they are sent to the\
+            \ buyer.\n- REPORTING: Invoices are shared with tax authorities after\
+            \ issuance, usually for compliance and audit purposes.\n- ZUGFERD: A hybrid\
+            \ eInvoicing format used in Germany combining PDF and XML for human and\
+            \ machine readability.\n- CTC: Continuous Transaction Controls involve\
+            \ real-time or near-real-time invoice validation and transmission to tax\
+            \ authorities.\n- NEMHANDEL: Denmark’s national infrastructure for eInvoicing\
+            \ that supports secure delivery via specific formats like OIOUBL.\n- FACE:\
+            \ Spain’s centralized system (FACe/FACeB2B) for routing invoices to government\
+            \ or private recipients.\n- VERIFACTU: Spain’s mechanism for validating\
+            \ and reporting sales invoices directly to the tax agency.\n"
+          enum:
+          - PEPPOL
+          - EINVOICE
+          - CLEARANCE
+          - REPORTING
+          - ZUGFERD
+          - CTC
+          - NEMHANDEL
+          - FACE
+          - VERIFACTU
+          example: PEPPOL
+          type: string
         issue_date:
           format: date
           type: string
@@ -2013,6 +2114,7 @@ components:
         overrides:
           $ref: '#/components/schemas/overrides'
       required:
+      - country
       - document_response
       - id
       - issue_date

--- a/spec/spi/generated/einvoicing/api/openapi.yaml
+++ b/spec/spi/generated/einvoicing/api/openapi.yaml
@@ -508,6 +508,7 @@ paths:
               "country": "DE",
               "transaction_type": "B2B",
               "model": "PEPPOL",
+              "document_type": "ubl-invoice",
               "issue_date": "2025-04-02",
               "tax_date": "2025-04-02",
               "currency_code": "EUR",
@@ -593,39 +594,39 @@ paths:
           \ \\\n  --header 'Content-Type: application/json' \\\n  --header 'Authorization:\
           \ {\"api_key\" : ... }' \\\n  --data '{\n    \"id\": \"INV-20221607\",\n\
           \    \"type\": \"INVOICE\",\n    \"country\": \"DE\",\n    \"transaction_type\"\
-          : \"B2B\",\n    \"model\": \"PEPPOL\",\n    \"issue_date\": \"2025-04-02\"\
-          ,\n    \"tax_date\": \"2025-04-02\",\n    \"currency_code\": \"EUR\",\n\
-          \    \"due_date\": \"2025-04-30\",\n    \"amount\": 114.0,\n    \"note\"\
-          : \"Payment due in 28 days.\",\n    \"accounting_supplier_party\": {\n \
-          \     \"name\": \"Example Seller GmbH\",\n      \"address\": {\n       \
-          \ \"line_1\": \"Hauptstr. 456\",\n        \"line_2\": \"Suite 5\",\n   \
-          \     \"zip\": \"50667\",\n        \"city\": \"Cologne\",\n        \"country\"\
+          : \"B2B\",\n    \"model\": \"PEPPOL\",\n    \"document_type\": \"ubl-invoice\"\
+          ,\n    \"issue_date\": \"2025-04-02\",\n    \"tax_date\": \"2025-04-02\"\
+          ,\n    \"currency_code\": \"EUR\",\n    \"due_date\": \"2025-04-30\",\n\
+          \    \"amount\": 114.0,\n    \"note\": \"Payment due in 28 days.\",\n  \
+          \  \"accounting_supplier_party\": {\n      \"name\": \"Example Seller GmbH\"\
+          ,\n      \"address\": {\n        \"line_1\": \"Hauptstr. 456\",\n      \
+          \  \"line_2\": \"Suite 5\",\n        \"zip\": \"50667\",\n        \"city\"\
+          : \"Cologne\",\n        \"country\": \"DE\"\n      },\n      \"tax_scheme\"\
+          : [\n        {\n          \"scheme\": \"VAT\",\n          \"id\": \"DE987654321\"\
+          \n        }\n      ]\n    },\n    \"accounting_customer_party\": {\n   \
+          \   \"name\": \"Example Buyer GmbH\",\n      \"address\": {\n        \"\
+          line_1\": \"Berliner Str. 123\",\n        \"line_2\": \"2nd Floor\",\n \
+          \       \"zip\": \"10115\",\n        \"city\": \"Berlin\",\n        \"country\"\
           : \"DE\"\n      },\n      \"tax_scheme\": [\n        {\n          \"scheme\"\
-          : \"VAT\",\n          \"id\": \"DE987654321\"\n        }\n      ]\n    },\n\
-          \    \"accounting_customer_party\": {\n      \"name\": \"Example Buyer GmbH\"\
-          ,\n      \"address\": {\n        \"line_1\": \"Berliner Str. 123\",\n  \
-          \      \"line_2\": \"2nd Floor\",\n        \"zip\": \"10115\",\n       \
-          \ \"city\": \"Berlin\",\n        \"country\": \"DE\"\n      },\n      \"\
-          tax_scheme\": [\n        {\n          \"scheme\": \"VAT\",\n          \"\
-          id\": \"DE123456789\"\n        }\n      ]\n    },\n    \"payment_means\"\
-          : [\n      {\n        \"code\": \"ONLINE_PAYMENT_SERVICE\",\n        \"\
-          payment_id\": \"PAY-2024-00987\",\n        \"card_account\": {\n       \
-          \   \"primary_account_number_id\": \"4111********1111\",\n          \"card_holder_name\"\
-          : \"Jane Smith\",\n          \"network_id\": \"MASTERCARD\"\n        }\n\
-          \      }\n    ],\n    \"lines\": [\n      {\n        \"id\": \"1\",\n  \
-          \      \"description\": \"Consulting Services - April\",\n        \"quantity\"\
-          : 1,\n        \"unit_price\": 100.0,\n        \"amount\": 100.0,\n     \
-          \   \"item_code\": \"CONS-APRIL\",\n        \"classified_tax_category\"\
-          : [\n          {\n            \"percentage\": 14,\n            \"category\"\
-          : \"VAT\",\n            \"country\": \"DE\"\n          }\n        ]\n  \
-          \    }\n    ],\n    \"tax_total\": {\n      \"tax_amount\": 14.0,\n    \
-          \  \"tax_sub_totals\": [\n        {\n          \"taxable_amount\": 100.0,\n\
-          \          \"tax_amount\": 14.0,\n          \"percentage\": 14,\n      \
-          \    \"country\": \"DE\",\n          \"category\": \"VAT\"\n        }\n\
-          \      ]\n    },\n    \"overrides\": {\n      \"country\": \"DE\", \n  \
-          \    \"transaction_type\": \"B2B\",\n      \"model\": \"PEPPOL\",\n    \
-          \  \"document_type\": \"ubl-invoice\",\n      \"field_mapping\": [\n   \
-          \     {\n          \"target\": \"Invoice.cbc:ID\",\n          \"source\"\
+          : \"VAT\",\n          \"id\": \"DE123456789\"\n        }\n      ]\n    },\n\
+          \    \"payment_means\": [\n      {\n        \"code\": \"ONLINE_PAYMENT_SERVICE\"\
+          ,\n        \"payment_id\": \"PAY-2024-00987\",\n        \"card_account\"\
+          : {\n          \"primary_account_number_id\": \"4111********1111\",\n  \
+          \        \"card_holder_name\": \"Jane Smith\",\n          \"network_id\"\
+          : \"MASTERCARD\"\n        }\n      }\n    ],\n    \"lines\": [\n      {\n\
+          \        \"id\": \"1\",\n        \"description\": \"Consulting Services\
+          \ - April\",\n        \"quantity\": 1,\n        \"unit_price\": 100.0,\n\
+          \        \"amount\": 100.0,\n        \"item_code\": \"CONS-APRIL\",\n  \
+          \      \"classified_tax_category\": [\n          {\n            \"percentage\"\
+          : 14,\n            \"category\": \"VAT\",\n            \"country\": \"DE\"\
+          \n          }\n        ]\n      }\n    ],\n    \"tax_total\": {\n      \"\
+          tax_amount\": 14.0,\n      \"tax_sub_totals\": [\n        {\n          \"\
+          taxable_amount\": 100.0,\n          \"tax_amount\": 14.0,\n          \"\
+          percentage\": 14,\n          \"country\": \"DE\",\n          \"category\"\
+          : \"VAT\"\n        }\n      ]\n    },\n    \"overrides\": {\n      \"country\"\
+          : \"DE\", \n      \"transaction_type\": \"B2B\",\n      \"model\": \"PEPPOL\"\
+          ,\n      \"document_type\": \"ubl-invoice\",\n      \"field_mapping\": [\n\
+          \        {\n          \"target\": \"Invoice.cbc:ID\",\n          \"source\"\
           : \"invoice.id\"\n        },\n        {\n          \"target\": \"Invoice.cbc:IssueDate\"\
           ,\n          \"source\": \"invoice.issue_date\"\n        },\n        {\n\
           \          \"target\": \"Invoice.cbc:InvoiceTypeCode\",\n          \"fixed_value\"\
@@ -700,6 +701,7 @@ paths:
               "country": "DE",
               "transaction_type": "B2B",
               "model": "PEPPOL",
+              "document_type": "ubl-creditnote",
               "issue_date": "2025-04-10",
               "tax_date": "2025-04-10",
               "currency_code": "EUR",
@@ -788,48 +790,48 @@ paths:
           \ \\\n  --header 'Content-Type: application/json' \\\n  --header 'Authorization:\
           \ {\"api_key\" : ... }' \\\n  --data '{\n    \"id\": \"CN-20002\",\n   \
           \ \"type\": \"CREDIT_NOTE\",\n    \"country\": \"DE\",\n    \"transaction_type\"\
-          : \"B2B\",\n    \"model\": \"PEPPOL\",\n    \"issue_date\": \"2025-04-10\"\
-          ,\n    \"tax_date\": \"2025-04-10\",\n    \"currency_code\": \"EUR\",\n\
-          \    \"due_date\": \"2025-04-30\",\n    \"amount\": 50.0,\n    \"note\"\
-          : \"Credit issued for April billing adjustment.\",\n    \"billing_reference\"\
-          : [\n      \"INV-10001\"\n    ],\n    \"accounting_supplier_party\": {\n\
-          \      \"name\": \"Example Seller GmbH\",\n      \"address\": {\n      \
-          \  \"line_1\": \"Hauptstr. 456\",\n        \"line_2\": \"Suite 5\",\n  \
-          \      \"zip\": \"50667\",\n        \"city\": \"Cologne\",\n        \"country\"\
-          : \"DE\"\n      },\n      \"tax_scheme\": [\n        {\n          \"scheme\"\
-          : \"VAT\",\n          \"id\": \"DE987654321\"\n        }\n      ]\n    },\n\
-          \    \"accounting_customer_party\": {\n      \"name\": \"Example Buyer GmbH\"\
-          ,\n      \"address\": {\n        \"line_1\": \"Berliner Str. 123\",\n  \
-          \      \"line_2\": \"2nd Floor\",\n        \"zip\": \"10115\",\n       \
-          \ \"city\": \"Berlin\",\n        \"country\": \"DE\"\n      },\n      \"\
+          : \"B2B\",\n    \"model\": \"PEPPOL\",\n    \"document_type\": \"ubl-creditnote\"\
+          ,\n    \"issue_date\": \"2025-04-10\",\n    \"tax_date\": \"2025-04-10\"\
+          ,\n    \"currency_code\": \"EUR\",\n    \"due_date\": \"2025-04-30\",\n\
+          \    \"amount\": 50.0,\n    \"note\": \"Credit issued for April billing\
+          \ adjustment.\",\n    \"billing_reference\": [\n      \"INV-10001\"\n  \
+          \  ],\n    \"accounting_supplier_party\": {\n      \"name\": \"Example Seller\
+          \ GmbH\",\n      \"address\": {\n        \"line_1\": \"Hauptstr. 456\",\n\
+          \        \"line_2\": \"Suite 5\",\n        \"zip\": \"50667\",\n       \
+          \ \"city\": \"Cologne\",\n        \"country\": \"DE\"\n      },\n      \"\
           tax_scheme\": [\n        {\n          \"scheme\": \"VAT\",\n          \"\
-          id\": \"DE123456789\"\n        }\n      ]\n    },\n    \"payment_means\"\
-          : [\n      {\n        \"code\": \"ONLINE_PAYMENT_SERVICE\",\n        \"\
-          payment_id\": \"PAY-2024-01002\",\n        \"card_account\": {\n       \
-          \   \"primary_account_number_id\": \"4111********2222\",\n          \"card_holder_name\"\
-          : \"John Doe\",\n          \"network_id\": \"VISA\"\n        }\n      }\n\
-          \    ],\n    \"lines\": [\n      {\n        \"id\": \"1\",\n        \"description\"\
-          : \"Refund for overcharge in April\",\n        \"quantity\": 1,\n      \
-          \  \"unit_price\": 50.0,\n        \"amount\": 50.0,\n        \"item_code\"\
-          : \"APRIL-REFUND\",\n        \"classified_tax_category\": [\n          {\n\
-          \            \"percentage\": 14,\n            \"category\": \"VAT\",\n \
-          \           \"country\": \"DE\"\n          }\n        ]\n      }\n    ],\n\
-          \    \"tax_total\": {\n      \"tax_amount\": 7.0,\n      \"tax_sub_totals\"\
-          : [\n        {\n          \"taxable_amount\": 50.0,\n          \"tax_amount\"\
-          : 7.0,\n          \"percentage\": 14,\n          \"country\": \"DE\",\n\
-          \          \"category\": \"VAT\"\n        }\n      ]\n    },\n    \"overrides\"\
-          : {\n      \"country\": \"DE\", \n      \"transaction_type\": \"B2B\",\n\
-          \      \"model\": \"PEPPOL\",\n      \"document_type\": \"ubl-creditnote\"\
-          ,\n      \"field_mapping\": [\n        {\n          \"target\": \"Creditnote.cbc:ID\"\
-          ,\n          \"source\": \"credit_note.id\"\n        },\n        {\n   \
-          \       \"target\": \"Creditnote.cbc:IssueDate\",\n          \"source\"\
-          : \"credit_note.issue_date\"\n        },\n        {\n          \"target\"\
-          : \"Creditnote.cbc:CreditNoteTypeCode\",\n          \"fixed_value\": \"\
-          396\"\n        },\n        {\n          \"target\": \"Creditnote.cbc:DocumentCurrencyCode\"\
-          ,\n          \"source\": \"credit_note.currency_code\"\n        },\n   \
-          \     {\n          \"target\": \"Creditnote.cac:BillingReference\",\n  \
-          \        \"expr\": \"invoiceResponse.events.exists(e, has(e.responseKey)\
-          \ && e.responseKey == 'Receipt Message ID') ? invoiceResponse.events.filter(e,\
+          id\": \"DE987654321\"\n        }\n      ]\n    },\n    \"accounting_customer_party\"\
+          : {\n      \"name\": \"Example Buyer GmbH\",\n      \"address\": {\n   \
+          \     \"line_1\": \"Berliner Str. 123\",\n        \"line_2\": \"2nd Floor\"\
+          ,\n        \"zip\": \"10115\",\n        \"city\": \"Berlin\",\n        \"\
+          country\": \"DE\"\n      },\n      \"tax_scheme\": [\n        {\n      \
+          \    \"scheme\": \"VAT\",\n          \"id\": \"DE123456789\"\n        }\n\
+          \      ]\n    },\n    \"payment_means\": [\n      {\n        \"code\": \"\
+          ONLINE_PAYMENT_SERVICE\",\n        \"payment_id\": \"PAY-2024-01002\",\n\
+          \        \"card_account\": {\n          \"primary_account_number_id\": \"\
+          4111********2222\",\n          \"card_holder_name\": \"John Doe\",\n   \
+          \       \"network_id\": \"VISA\"\n        }\n      }\n    ],\n    \"lines\"\
+          : [\n      {\n        \"id\": \"1\",\n        \"description\": \"Refund\
+          \ for overcharge in April\",\n        \"quantity\": 1,\n        \"unit_price\"\
+          : 50.0,\n        \"amount\": 50.0,\n        \"item_code\": \"APRIL-REFUND\"\
+          ,\n        \"classified_tax_category\": [\n          {\n            \"percentage\"\
+          : 14,\n            \"category\": \"VAT\",\n            \"country\": \"DE\"\
+          \n          }\n        ]\n      }\n    ],\n    \"tax_total\": {\n      \"\
+          tax_amount\": 7.0,\n      \"tax_sub_totals\": [\n        {\n          \"\
+          taxable_amount\": 50.0,\n          \"tax_amount\": 7.0,\n          \"percentage\"\
+          : 14,\n          \"country\": \"DE\",\n          \"category\": \"VAT\"\n\
+          \        }\n      ]\n    },\n    \"overrides\": {\n      \"country\": \"\
+          DE\", \n      \"transaction_type\": \"B2B\",\n      \"model\": \"PEPPOL\"\
+          ,\n      \"document_type\": \"ubl-creditnote\",\n      \"field_mapping\"\
+          : [\n        {\n          \"target\": \"Creditnote.cbc:ID\",\n         \
+          \ \"source\": \"credit_note.id\"\n        },\n        {\n          \"target\"\
+          : \"Creditnote.cbc:IssueDate\",\n          \"source\": \"credit_note.issue_date\"\
+          \n        },\n        {\n          \"target\": \"Creditnote.cbc:CreditNoteTypeCode\"\
+          ,\n          \"fixed_value\": \"396\"\n        },\n        {\n         \
+          \ \"target\": \"Creditnote.cbc:DocumentCurrencyCode\",\n          \"source\"\
+          : \"credit_note.currency_code\"\n        },\n        {\n          \"target\"\
+          : \"Creditnote.cac:BillingReference\",\n          \"expr\": \"invoiceResponse.events.exists(e,\
+          \ has(e.responseKey) && e.responseKey == 'Receipt Message ID') ? invoiceResponse.events.filter(e,\
           \ has(e.responseKey) && e.responseKey == 'Receipt Message ID').map(e, e.responseValue)[0]\
           \ : null\"\n        },\n        {\n          \"target\": \"Creditnote.cac:AccountingSupplierParty.cac:Party.cbc:EndpointID\"\
           ,\n          \"source\": \"business.legal_entity.company_id\"\n        },\n\
@@ -918,6 +920,7 @@ paths:
               "country": "DE",
               "transaction_type": "B2B",
               "model": "PEPPOL",
+              "document_type": "ubl-applicationresponse",
               "issue_date": "2025-04-04",
               "sender_party": {
                 "legal_entity": {
@@ -954,6 +957,7 @@ paths:
               "country": "DE",
               "transaction_type": "B2B",
               "model": "PEPPOL",
+              "document_type": "ubl-applicationresponse",
               "issue_date": "2025-04-03",
               "sender_party": {
                 "legal_entity": {
@@ -1982,6 +1986,10 @@ components:
           - VERIFACTU
           example: PEPPOL
           type: string
+        document_type:
+          description: Type of business document.
+          example: ubl-invoice
+          type: string
         issue_date:
           description: The date when the document was issued. Format "YYYY-MM-DD"
           format: date
@@ -2039,10 +2047,12 @@ components:
       - amount
       - country
       - currency_code
+      - document_type
       - dueDate
       - id
       - issue_date
       - lines
+      - model
       - tax_date
       - tax_total
       - type
@@ -2102,6 +2112,10 @@ components:
           - VERIFACTU
           example: PEPPOL
           type: string
+        document_type:
+          description: Type of business document.
+          example: ubl-applicationresponse
+          type: string
         issue_date:
           format: date
           type: string
@@ -2116,8 +2130,10 @@ components:
       required:
       - country
       - document_response
+      - document_type
       - id
       - issue_date
+      - model
       - receiver_party
       - sender_party
       - type

--- a/spec/spi/generated/einvoicing/api/openapi.yaml
+++ b/spec/spi/generated/einvoicing/api/openapi.yaml
@@ -2188,7 +2188,7 @@ components:
         - mime_type: application/xml
           document_url: https://provider.com/downloads/invoice-20250402.xml
           expires_at: 2025-03-28T09:24:29Z
-        model: peppol
+        model: PEPPOL
       properties:
         document_id:
           type: string

--- a/spec/spi/generated/einvoicing/api/openapi.yaml
+++ b/spec/spi/generated/einvoicing/api/openapi.yaml
@@ -2047,7 +2047,6 @@ components:
       - amount
       - country
       - currency_code
-      - document_type
       - dueDate
       - id
       - issue_date
@@ -2130,7 +2129,6 @@ components:
       required:
       - country
       - document_response
-      - document_type
       - id
       - issue_date
       - model

--- a/spec/spi/openapi_einvoicing.yml
+++ b/spec/spi/openapi_einvoicing.yml
@@ -261,32 +261,8 @@ paths:
         - name: model
           in: query
           required: true
-          description: |
-            Indicates the eInvoicing flow model that governs the document exchange and processing mechanism. 
-            Different countries adopt different models based on legal, technical, and administrative mandates.
-            Supported values:
-            - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
-            - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
-            - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
-            - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
-            - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
-            - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
-            - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
-            - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
-            - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
           schema:
-            type: string
-            enum:
-              - PEPPOL
-              - EINVOICE
-              - CLEARANCE
-              - REPORTING
-              - ZUGFERD
-              - CTC
-              - NEMHANDEL
-              - FACE
-              - VERIFACTU
-            example: "PEPPOL"
+            $ref: '#/components/schemas/model'
         - name: document_type
           in: query
           required: true
@@ -1555,32 +1531,8 @@ paths:
         - name: model
           in: query
           required: true
-          description: |
-            Indicates the eInvoicing flow model that governs the document exchange and processing mechanism. 
-            Different countries adopt different models based on legal, technical, and administrative mandates.
-            Supported values:
-            - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
-            - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
-            - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
-            - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
-            - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
-            - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
-            - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
-            - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
-            - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
           schema:
-            type: string
-            enum:
-              - PEPPOL
-              - EINVOICE
-              - CLEARANCE
-              - REPORTING
-              - ZUGFERD
-              - CTC
-              - NEMHANDEL
-              - FACE
-              - VERIFACTU
-            example: "PEPPOL"
+            $ref: '#/components/schemas/model'
         - name: document_type
           in: query
           required: true
@@ -1718,6 +1670,32 @@ paths:
     $ref: ./paths/health.yml
 components:
   schemas:
+    model:
+      type: string
+      description: |
+        Indicates the eInvoicing flow model that governs the document exchange and processing mechanism.
+        Different countries adopt different models based on legal, technical, and administrative mandates.
+        Supported values:
+        - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
+        - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
+        - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
+        - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
+        - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
+        - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
+        - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
+        - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
+        - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
+      enum:
+        - PEPPOL
+        - EINVOICE
+        - CLEARANCE
+        - REPORTING
+        - ZUGFERD
+        - CTC
+        - NEMHANDEL
+        - FACE
+        - VERIFACTU
+      example: "PEPPOL"
     activation:
       type: object
       properties:
@@ -1755,31 +1733,7 @@ components:
       type: object
       properties:
         model:
-          type: string
-          description: |
-            Indicates the eInvoicing flow model that governs the document exchange and processing mechanism. 
-            Different countries adopt different models based on legal, technical, and administrative mandates.
-            Supported values:
-            - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
-            - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
-            - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
-            - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
-            - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
-            - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
-            - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
-            - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
-            - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
-          enum:
-            - PEPPOL
-            - EINVOICE
-            - CLEARANCE
-            - REPORTING
-            - ZUGFERD
-            - CTC
-            - NEMHANDEL
-            - FACE
-            - VERIFACTU
-          example: "PEPPOL"
+          $ref: '#/components/schemas/model'
         country:
           type: string
           description: ISO 3166-1 alpha-2 country code where the e-invoicing activation
@@ -1839,31 +1793,7 @@ components:
           enum: [B2B, B2C, B2G]
           example: "B2B"
         model:
-          type: string
-          description: |
-            Indicates the eInvoicing flow model that governs the document exchange and processing mechanism. 
-            Different countries adopt different models based on legal, technical, and administrative mandates.
-            Supported values:
-            - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
-            - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
-            - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
-            - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
-            - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
-            - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
-            - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
-            - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
-            - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
-          enum:
-            - PEPPOL
-            - EINVOICE
-            - CLEARANCE
-            - REPORTING
-            - ZUGFERD
-            - CTC
-            - NEMHANDEL
-            - FACE
-            - VERIFACTU
-          example: "PEPPOL"
+          $ref: '#/components/schemas/model'
         document_type:
           type: string
           description: Type of business document.
@@ -2017,31 +1947,7 @@ components:
           enum: [ B2B, B2C, B2G ]
           example: "B2B"
         model:
-          type: string
-          description: |
-            Indicates the eInvoicing flow model that governs the document exchange and processing mechanism. 
-            Different countries adopt different models based on legal, technical, and administrative mandates.
-            Supported values:
-            - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
-            - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
-            - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
-            - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
-            - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
-            - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
-            - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
-            - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
-            - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
-          enum:
-            - PEPPOL
-            - EINVOICE
-            - CLEARANCE
-            - REPORTING
-            - ZUGFERD
-            - CTC
-            - NEMHANDEL
-            - FACE
-            - VERIFACTU
-          example: "PEPPOL"
+          $ref: '#/components/schemas/model'
         document_type:
           type: string
           description: Type of business document.
@@ -2271,31 +2177,7 @@ components:
           enum: [ B2B, B2C, B2G ]
           example: "B2B"
         model:
-          type: string
-          description: |
-            Indicates the eInvoicing flow model that governs the document exchange and processing mechanism. 
-            Different countries adopt different models based on legal, technical, and administrative mandates.
-            Supported values:
-            - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
-            - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
-            - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
-            - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
-            - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
-            - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
-            - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
-            - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
-            - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
-          enum:
-            - PEPPOL
-            - EINVOICE
-            - CLEARANCE
-            - REPORTING
-            - ZUGFERD
-            - CTC
-            - NEMHANDEL
-            - FACE
-            - VERIFACTU
-          example: "PEPPOL"
+          $ref: '#/components/schemas/model'
         document_type:
           type: string
           description: Type of business document.
@@ -2406,31 +2288,7 @@ components:
           enum: [ B2B, B2C, B2G ]
           example: "B2B"
         model:
-          type: string
-          description: |
-            Indicates the eInvoicing flow model that governs the document exchange and processing mechanism. 
-            Different countries adopt different models based on legal, technical, and administrative mandates.
-            Supported values:
-            - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
-            - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
-            - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
-            - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
-            - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
-            - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
-            - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
-            - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
-            - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
-          enum:
-            - PEPPOL
-            - EINVOICE
-            - CLEARANCE
-            - REPORTING
-            - ZUGFERD
-            - CTC
-            - NEMHANDEL
-            - FACE
-            - VERIFACTU
-          example: "PEPPOL"
+          $ref: '#/components/schemas/model'
         document_type:
           type: string
           description: Type of business document.
@@ -2671,39 +2529,14 @@ components:
                 description: The time until which the document URL is valid.
                 example: 2025-03-28T09:24:29Z
         model:
-          description: |
-            Indicates the eInvoicing flow model that governs the document exchange and processing mechanism. 
-            Different countries adopt different models based on legal, technical, and administrative mandates.
-            Supported values:
-              - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
-              - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
-              - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
-              - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
-              - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
-              - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
-              - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
-              - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
-              - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
-              schema:
-                type: string
-                enum:
-                  - PEPPOL
-                  - EINVOICE
-                  - CLEARANCE
-                  - REPORTING
-                  - ZUGFERD
-                  - CTC
-                  - NEMHANDEL
-                  - FACE
-                  - VERIFACTU
-                example: "PEPPOL"
+          $ref: '#/components/schemas/model'
       example:
         request_id: a3d56940-2827-4b87-a229-00d8b95cbe77
         documents:
           - mime_type: "application/xml"
             document_url: https://provider.com/downloads/invoice-20250402.xml
             expires_at: '2025-03-28T09:24:29Z'
-        model: peppol
+        model: PEPPOL
     error_response:
       type: object
       properties:

--- a/spec/spi/openapi_einvoicing.yml
+++ b/spec/spi/openapi_einvoicing.yml
@@ -2232,7 +2232,6 @@ components:
         - type
         - country
         - model
-        - document_type
         - issue_date
         - tax_date
         - currency_code
@@ -2250,7 +2249,6 @@ components:
         - type
         - country
         - model
-        - document_type
         - issue_date
         - sender_party
         - receiver_party

--- a/spec/spi/openapi_einvoicing.yml
+++ b/spec/spi/openapi_einvoicing.yml
@@ -365,6 +365,9 @@ paths:
               --data '{
                 "id": "INV-10001",
                 "type": "INVOICE",
+                "country": "DE",
+                "transaction_type": "B2B",
+                "model": "PEPPOL",
                 "issue_date": "2025-04-02",
                 "tax_date": "2025-04-02",
                 "currency_code": "EUR",
@@ -455,6 +458,9 @@ paths:
               --data '{
                 "id": "INV-20221607",
                 "type": "INVOICE",
+                "country": "DE",
+                "transaction_type": "B2B",
+                "model": "PEPPOL",
                 "issue_date": "2025-04-02",
                 "tax_date": "2025-04-02",
                 "currency_code": "EUR",
@@ -679,6 +685,9 @@ paths:
               --data '{
                 "id": "CN-20002",
                 "type": "CREDIT_NOTE",
+                "country": "DE",
+                "transaction_type": "B2B",
+                "model": "PEPPOL",
                 "issue_date": "2025-04-10",
                 "tax_date": "2025-04-10",
                 "currency_code": "EUR",
@@ -772,6 +781,9 @@ paths:
               --data '{
                 "id": "CN-20002",
                 "type": "CREDIT_NOTE",
+                "country": "DE",
+                "transaction_type": "B2B",
+                "model": "PEPPOL",
                 "issue_date": "2025-04-10",
                 "tax_date": "2025-04-10",
                 "currency_code": "EUR",
@@ -1038,6 +1050,9 @@ paths:
               --data '{
                 "id": "APPRESP-20250402-002",
                 "type": "APPLICATION_RESPONSE",
+                "country": "DE",
+                "transaction_type": "B2B",
+                "model": "PEPPOL",
                 "issue_date": "2025-04-04",
                 "sender_party": {
                   "legal_entity": {
@@ -1072,6 +1087,9 @@ paths:
               --data '{
                 "id": "APPRESP-20240401-001",
                 "type": "APPLICATION_RESPONSE",
+                "country": "DE",
+                "transaction_type": "B2B",
+                "model": "PEPPOL",
                 "issue_date": "2025-04-03",
                 "sender_party": {
                   "legal_entity": {
@@ -1983,6 +2001,41 @@ components:
             - INVOICE
             - CREDIT_NOTE
           description: Type of document, either an invoice or a credit note.
+        country:
+          type: string
+          description: The ISO country code for the scenario.
+          example: "DE"
+        transaction_type:
+          type: string
+          description: The type of transaction (B2B, B2C, B2G).
+          enum: [ B2B, B2C, B2G ]
+          example: "B2B"
+        model:
+          type: string
+          description: |
+            Indicates the eInvoicing flow model that governs the document exchange and processing mechanism. 
+            Different countries adopt different models based on legal, technical, and administrative mandates.
+            Supported values:
+            - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
+            - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
+            - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
+            - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
+            - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
+            - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
+            - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
+            - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
+            - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
+          enum:
+            - PEPPOL
+            - EINVOICE
+            - CLEARANCE
+            - REPORTING
+            - ZUGFERD
+            - CTC
+            - NEMHANDEL
+            - FACE
+            - VERIFACTU
+          example: "PEPPOL"
         issue_date:
           type: string
           format: date
@@ -2167,6 +2220,7 @@ components:
       required:
         - id
         - type
+        - country
         - issue_date
         - tax_date
         - currency_code
@@ -2182,6 +2236,7 @@ components:
       required:
         - id
         - type
+        - country
         - issue_date
         - sender_party
         - receiver_party
@@ -2194,7 +2249,41 @@ components:
           enum:
             - APPLICATION_RESPONSE
           description: The document type discriminator indicating this is an application response.
-
+        country:
+          type: string
+          description: The ISO country code for the scenario.
+          example: "DE"
+        transaction_type:
+          type: string
+          description: The type of transaction (B2B, B2C, B2G).
+          enum: [ B2B, B2C, B2G ]
+          example: "B2B"
+        model:
+          type: string
+          description: |
+            Indicates the eInvoicing flow model that governs the document exchange and processing mechanism. 
+            Different countries adopt different models based on legal, technical, and administrative mandates.
+            Supported values:
+            - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
+            - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
+            - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
+            - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
+            - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
+            - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
+            - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
+            - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
+            - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
+          enum:
+            - PEPPOL
+            - EINVOICE
+            - CLEARANCE
+            - REPORTING
+            - ZUGFERD
+            - CTC
+            - NEMHANDEL
+            - FACE
+            - VERIFACTU
+          example: "PEPPOL"
         issue_date:
           type: string
           format: date

--- a/spec/spi/openapi_einvoicing.yml
+++ b/spec/spi/openapi_einvoicing.yml
@@ -261,8 +261,32 @@ paths:
         - name: model
           in: query
           required: true
+          description: |
+            Indicates the eInvoicing flow model that governs the document exchange and processing mechanism. 
+            Different countries adopt different models based on legal, technical, and administrative mandates.
+            Supported values:
+            - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
+            - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
+            - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
+            - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
+            - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
+            - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
+            - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
+            - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
+            - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
           schema:
-            $ref: '#/components/schemas/model'
+            type: string
+            enum:
+              - PEPPOL
+              - EINVOICE
+              - CLEARANCE
+              - REPORTING
+              - ZUGFERD
+              - CTC
+              - NEMHANDEL
+              - FACE
+              - VERIFACTU
+            example: "PEPPOL"
         - name: document_type
           in: query
           required: true
@@ -1531,8 +1555,32 @@ paths:
         - name: model
           in: query
           required: true
+          description: |
+            Indicates the eInvoicing flow model that governs the document exchange and processing mechanism. 
+            Different countries adopt different models based on legal, technical, and administrative mandates.
+            Supported values:
+            - PEPPOL: A standardized, secure eInvoicing network enabling cross-border electronic document exchange between businesses and governments.
+            - EINVOICE: Traditional eInvoicing model where invoices are digitally exchanged between businesses and sometimes stored.
+            - CLEARANCE: Invoices must be pre-approved by a tax authority before they are sent to the buyer.
+            - REPORTING: Invoices are shared with tax authorities after issuance, usually for compliance and audit purposes.
+            - ZUGFERD: A hybrid eInvoicing format used in Germany combining PDF and XML for human and machine readability.
+            - CTC: Continuous Transaction Controls involve real-time or near-real-time invoice validation and transmission to tax authorities.
+            - NEMHANDEL: Denmark’s national infrastructure for eInvoicing that supports secure delivery via specific formats like OIOUBL.
+            - FACE: Spain’s centralized system (FACe/FACeB2B) for routing invoices to government or private recipients.
+            - VERIFACTU: Spain’s mechanism for validating and reporting sales invoices directly to the tax agency.
           schema:
-            $ref: '#/components/schemas/model'
+            type: string
+            enum:
+              - PEPPOL
+              - EINVOICE
+              - CLEARANCE
+              - REPORTING
+              - ZUGFERD
+              - CTC
+              - NEMHANDEL
+              - FACE
+              - VERIFACTU
+            example: "PEPPOL"
         - name: document_type
           in: query
           required: true

--- a/spec/spi/openapi_einvoicing.yml
+++ b/spec/spi/openapi_einvoicing.yml
@@ -368,6 +368,7 @@ paths:
                 "country": "DE",
                 "transaction_type": "B2B",
                 "model": "PEPPOL",
+                "document_type": "ubl-invoice",
                 "issue_date": "2025-04-02",
                 "tax_date": "2025-04-02",
                 "currency_code": "EUR",
@@ -461,6 +462,7 @@ paths:
                 "country": "DE",
                 "transaction_type": "B2B",
                 "model": "PEPPOL",
+                "document_type": "ubl-invoice",
                 "issue_date": "2025-04-02",
                 "tax_date": "2025-04-02",
                 "currency_code": "EUR",
@@ -688,6 +690,7 @@ paths:
                 "country": "DE",
                 "transaction_type": "B2B",
                 "model": "PEPPOL",
+                "document_type": "ubl-creditnote",
                 "issue_date": "2025-04-10",
                 "tax_date": "2025-04-10",
                 "currency_code": "EUR",
@@ -784,6 +787,7 @@ paths:
                 "country": "DE",
                 "transaction_type": "B2B",
                 "model": "PEPPOL",
+                "document_type": "ubl-creditnote",
                 "issue_date": "2025-04-10",
                 "tax_date": "2025-04-10",
                 "currency_code": "EUR",
@@ -1053,6 +1057,7 @@ paths:
                 "country": "DE",
                 "transaction_type": "B2B",
                 "model": "PEPPOL",
+                "document_type": "ubl-applicationresponse",
                 "issue_date": "2025-04-04",
                 "sender_party": {
                   "legal_entity": {
@@ -1090,6 +1095,7 @@ paths:
                 "country": "DE",
                 "transaction_type": "B2B",
                 "model": "PEPPOL",
+                "document_type": "ubl-applicationresponse",
                 "issue_date": "2025-04-03",
                 "sender_party": {
                   "legal_entity": {
@@ -2036,6 +2042,10 @@ components:
             - FACE
             - VERIFACTU
           example: "PEPPOL"
+        document_type:
+          type: string
+          description: Type of business document.
+          example: "ubl-invoice"
         issue_date:
           type: string
           format: date
@@ -2221,6 +2231,8 @@ components:
         - id
         - type
         - country
+        - model
+        - document_type
         - issue_date
         - tax_date
         - currency_code
@@ -2237,6 +2249,8 @@ components:
         - id
         - type
         - country
+        - model
+        - document_type
         - issue_date
         - sender_party
         - receiver_party
@@ -2284,6 +2298,10 @@ components:
             - FACE
             - VERIFACTU
           example: "PEPPOL"
+        document_type:
+          type: string
+          description: Type of business document.
+          example: "ubl-applicationresponse"
         issue_date:
           type: string
           format: date


### PR DESCRIPTION
## JIRA URL
https://mychargebee.atlassian.net/browse/TAXENGG-3818

## JSON schema changes
- previously there was just `retrieve_activations_supported` which was for both retrieving activations for countries as well as listing different business entities configured for the merchant on the provider end, now seperated it to `retrieve_business_entities_supported`
- added attribute `retrieve_input_fields_supported`

## Request model changes
- included `country`, `model`, `transaction_type` and `document_type` as part of main request and not `overrides` object