### PR TITLE
TAXENGG-3893 (feat): Support Chargebee custom fields in e-invoicing SPI document submission

### DIFF
--- a/spec/spi/generated/einvoicing/api/openapi.yaml
+++ b/spec/spi/generated/einvoicing/api/openapi.yaml
@@ -1970,6 +1970,64 @@ components:
             relevant to the Document as a whole. Such as the reason for any correction
             or assignment note in case the document has been factored.
           type: string
+        custom_fields:
+          additionalProperties:
+            type: string
+          description: |
+            Merchant-defined custom field values keyed by Chargebee API name
+            (for example, `cf_po_number`). Values are serialized as strings.
+
+            Used as:
+            - `main_document.custom_fields` — invoice / credit note fields
+            - `accounting_customer_party.custom_fields` — customer fields
+            - `main_document.subscription_custom_fields` — subscription fields when the
+              document has a single subscription (set once at document level)
+            - `lines[].subscription_custom_fields` — subscription fields when the
+              document is consolidated / multi-subscription (resolved per line by Chargebee)
+            - `lines[].product_custom_fields` — product / item-price fields for the
+              product on that line (always line-level)
+
+            Adapter guidance for subscription fields:
+            - Prefer `lines[].subscription_custom_fields` when present on a line
+            - Otherwise use `document.subscription_custom_fields`
+
+            Examples: `document.custom_fields.cf_invoice_reference`,
+            `document.subscription_custom_fields.cf_contract_id`,
+            `lines[].subscription_custom_fields.cf_contract_id`,
+            `lines[].product_custom_fields.cf_hs_code`.
+          example:
+            cf_po_number: PO-12345
+            cf_cost_center: CC-42
+          type: object
+        subscription_custom_fields:
+          additionalProperties:
+            type: string
+          description: |
+            Merchant-defined custom field values keyed by Chargebee API name
+            (for example, `cf_po_number`). Values are serialized as strings.
+
+            Used as:
+            - `main_document.custom_fields` — invoice / credit note fields
+            - `accounting_customer_party.custom_fields` — customer fields
+            - `main_document.subscription_custom_fields` — subscription fields when the
+              document has a single subscription (set once at document level)
+            - `lines[].subscription_custom_fields` — subscription fields when the
+              document is consolidated / multi-subscription (resolved per line by Chargebee)
+            - `lines[].product_custom_fields` — product / item-price fields for the
+              product on that line (always line-level)
+
+            Adapter guidance for subscription fields:
+            - Prefer `lines[].subscription_custom_fields` when present on a line
+            - Otherwise use `document.subscription_custom_fields`
+
+            Examples: `document.custom_fields.cf_invoice_reference`,
+            `document.subscription_custom_fields.cf_contract_id`,
+            `lines[].subscription_custom_fields.cf_contract_id`,
+            `lines[].product_custom_fields.cf_hs_code`.
+          example:
+            cf_po_number: PO-12345
+            cf_cost_center: CC-42
+          type: object
         billing_reference:
           description: A group of business terms providing information on one or more
             preceding invoices. This enhances traceability in workflows where a document
@@ -2393,6 +2451,35 @@ components:
           type: string
       required:
       - registrationName
+      type: object
+    custom_fields:
+      additionalProperties:
+        type: string
+      description: |
+        Merchant-defined custom field values keyed by Chargebee API name
+        (for example, `cf_po_number`). Values are serialized as strings.
+
+        Used as:
+        - `main_document.custom_fields` — invoice / credit note fields
+        - `accounting_customer_party.custom_fields` — customer fields
+        - `main_document.subscription_custom_fields` — subscription fields when the
+          document has a single subscription (set once at document level)
+        - `lines[].subscription_custom_fields` — subscription fields when the
+          document is consolidated / multi-subscription (resolved per line by Chargebee)
+        - `lines[].product_custom_fields` — product / item-price fields for the
+          product on that line (always line-level)
+
+        Adapter guidance for subscription fields:
+        - Prefer `lines[].subscription_custom_fields` when present on a line
+        - Otherwise use `document.subscription_custom_fields`
+
+        Examples: `document.custom_fields.cf_invoice_reference`,
+        `document.subscription_custom_fields.cf_contract_id`,
+        `lines[].subscription_custom_fields.cf_contract_id`,
+        `lines[].product_custom_fields.cf_hs_code`.
+      example:
+        cf_po_number: PO-12345
+        cf_cost_center: CC-42
       type: object
     callback_document_status:
       properties:
@@ -2865,6 +2952,35 @@ components:
           type: array
         legal_entity:
           $ref: '#/components/schemas/party_legal_entity'
+        custom_fields:
+          additionalProperties:
+            type: string
+          description: |
+            Merchant-defined custom field values keyed by Chargebee API name
+            (for example, `cf_po_number`). Values are serialized as strings.
+
+            Used as:
+            - `main_document.custom_fields` — invoice / credit note fields
+            - `accounting_customer_party.custom_fields` — customer fields
+            - `main_document.subscription_custom_fields` — subscription fields when the
+              document has a single subscription (set once at document level)
+            - `lines[].subscription_custom_fields` — subscription fields when the
+              document is consolidated / multi-subscription (resolved per line by Chargebee)
+            - `lines[].product_custom_fields` — product / item-price fields for the
+              product on that line (always line-level)
+
+            Adapter guidance for subscription fields:
+            - Prefer `lines[].subscription_custom_fields` when present on a line
+            - Otherwise use `document.subscription_custom_fields`
+
+            Examples: `document.custom_fields.cf_invoice_reference`,
+            `document.subscription_custom_fields.cf_contract_id`,
+            `lines[].subscription_custom_fields.cf_contract_id`,
+            `lines[].product_custom_fields.cf_hs_code`.
+          example:
+            cf_po_number: PO-12345
+            cf_cost_center: CC-42
+          type: object
       required:
       - address
       - legalEntity
@@ -2909,6 +3025,64 @@ components:
           description: The unique identifier (in Chargebee) of the product corresponding
             to the line.
           type: string
+        subscription_custom_fields:
+          additionalProperties:
+            type: string
+          description: |
+            Merchant-defined custom field values keyed by Chargebee API name
+            (for example, `cf_po_number`). Values are serialized as strings.
+
+            Used as:
+            - `main_document.custom_fields` — invoice / credit note fields
+            - `accounting_customer_party.custom_fields` — customer fields
+            - `main_document.subscription_custom_fields` — subscription fields when the
+              document has a single subscription (set once at document level)
+            - `lines[].subscription_custom_fields` — subscription fields when the
+              document is consolidated / multi-subscription (resolved per line by Chargebee)
+            - `lines[].product_custom_fields` — product / item-price fields for the
+              product on that line (always line-level)
+
+            Adapter guidance for subscription fields:
+            - Prefer `lines[].subscription_custom_fields` when present on a line
+            - Otherwise use `document.subscription_custom_fields`
+
+            Examples: `document.custom_fields.cf_invoice_reference`,
+            `document.subscription_custom_fields.cf_contract_id`,
+            `lines[].subscription_custom_fields.cf_contract_id`,
+            `lines[].product_custom_fields.cf_hs_code`.
+          example:
+            cf_po_number: PO-12345
+            cf_cost_center: CC-42
+          type: object
+        product_custom_fields:
+          additionalProperties:
+            type: string
+          description: |
+            Merchant-defined custom field values keyed by Chargebee API name
+            (for example, `cf_po_number`). Values are serialized as strings.
+
+            Used as:
+            - `main_document.custom_fields` — invoice / credit note fields
+            - `accounting_customer_party.custom_fields` — customer fields
+            - `main_document.subscription_custom_fields` — subscription fields when the
+              document has a single subscription (set once at document level)
+            - `lines[].subscription_custom_fields` — subscription fields when the
+              document is consolidated / multi-subscription (resolved per line by Chargebee)
+            - `lines[].product_custom_fields` — product / item-price fields for the
+              product on that line (always line-level)
+
+            Adapter guidance for subscription fields:
+            - Prefer `lines[].subscription_custom_fields` when present on a line
+            - Otherwise use `document.subscription_custom_fields`
+
+            Examples: `document.custom_fields.cf_invoice_reference`,
+            `document.subscription_custom_fields.cf_contract_id`,
+            `lines[].subscription_custom_fields.cf_contract_id`,
+            `lines[].product_custom_fields.cf_hs_code`.
+          example:
+            cf_po_number: PO-12345
+            cf_cost_center: CC-42
+          type: object
         classified_tax_category:
           description: "List of tax categories applicable to the invoice line, such\
             \ as VAT or other indirect taxes."

--- a/spec/spi/generated/einvoicing/api/openapi.yaml
+++ b/spec/spi/generated/einvoicing/api/openapi.yaml
@@ -1971,63 +1971,16 @@ components:
             or assignment note in case the document has been factored.
           type: string
         custom_fields:
-          additionalProperties:
-            type: string
-          description: |
-            Merchant-defined custom field values keyed by Chargebee API name
-            (for example, `cf_po_number`). Values are serialized as strings.
-
-            Used as:
-            - `main_document.custom_fields` — invoice / credit note fields
-            - `accounting_customer_party.custom_fields` — customer fields
-            - `main_document.subscription_custom_fields` — subscription fields when the
-              document has a single subscription (set once at document level)
-            - `lines[].subscription_custom_fields` — subscription fields when the
-              document is consolidated / multi-subscription (resolved per line by Chargebee)
-            - `lines[].product_custom_fields` — product / item-price fields for the
-              product on that line (always line-level)
-
-            Adapter guidance for subscription fields:
-            - Prefer `lines[].subscription_custom_fields` when present on a line
-            - Otherwise use `document.subscription_custom_fields`
-
-            Examples: `document.custom_fields.cf_invoice_reference`,
-            `document.subscription_custom_fields.cf_contract_id`,
-            `lines[].subscription_custom_fields.cf_contract_id`,
-            `lines[].product_custom_fields.cf_hs_code`.
-          example:
-            cf_po_number: PO-12345
-            cf_cost_center: CC-42
-          type: object
+          allOf:
+          - $ref: '#/components/schemas/custom_fields'
+          description: Invoice or credit note custom field values keyed by API name
+            (e.g. `cf_invoice_reference`).
         subscription_custom_fields:
-          additionalProperties:
-            type: string
+          allOf:
+          - $ref: '#/components/schemas/custom_fields'
           description: |
-            Merchant-defined custom field values keyed by Chargebee API name
-            (for example, `cf_po_number`). Values are serialized as strings.
-
-            Used as:
-            - `main_document.custom_fields` — invoice / credit note fields
-            - `accounting_customer_party.custom_fields` — customer fields
-            - `main_document.subscription_custom_fields` — subscription fields when the
-              document has a single subscription (set once at document level)
-            - `lines[].subscription_custom_fields` — subscription fields when the
-              document is consolidated / multi-subscription (resolved per line by Chargebee)
-            - `lines[].product_custom_fields` — product / item-price fields for the
-              product on that line (always line-level)
-
-            Adapter guidance for subscription fields:
-            - Prefer `lines[].subscription_custom_fields` when present on a line
-            - Otherwise use `document.subscription_custom_fields`
-
-            Examples: `document.custom_fields.cf_invoice_reference`,
-            `document.subscription_custom_fields.cf_contract_id`,
-            `lines[].subscription_custom_fields.cf_contract_id`,
-            `lines[].product_custom_fields.cf_hs_code`.
-          example:
-            cf_po_number: PO-12345
-            cf_cost_center: CC-42
-          type: object
+            Subscription custom fields for single-subscription documents (set once at document level).
+            For consolidated / multi-subscription documents, use `lines[].subscription_custom_fields` instead.
         billing_reference:
           description: A group of business terms providing information on one or more
             preceding invoices. This enhances traceability in workflows where a document
@@ -2458,25 +2411,6 @@ components:
       description: |
         Merchant-defined custom field values keyed by Chargebee API name
         (for example, `cf_po_number`). Values are serialized as strings.
-
-        Used as:
-        - `main_document.custom_fields` — invoice / credit note fields
-        - `accounting_customer_party.custom_fields` — customer fields
-        - `main_document.subscription_custom_fields` — subscription fields when the
-          document has a single subscription (set once at document level)
-        - `lines[].subscription_custom_fields` — subscription fields when the
-          document is consolidated / multi-subscription (resolved per line by Chargebee)
-        - `lines[].product_custom_fields` — product / item-price fields for the
-          product on that line (always line-level)
-
-        Adapter guidance for subscription fields:
-        - Prefer `lines[].subscription_custom_fields` when present on a line
-        - Otherwise use `document.subscription_custom_fields`
-
-        Examples: `document.custom_fields.cf_invoice_reference`,
-        `document.subscription_custom_fields.cf_contract_id`,
-        `lines[].subscription_custom_fields.cf_contract_id`,
-        `lines[].product_custom_fields.cf_hs_code`.
       example:
         cf_po_number: PO-12345
         cf_cost_center: CC-42
@@ -2953,34 +2887,9 @@ components:
         legal_entity:
           $ref: '#/components/schemas/party_legal_entity'
         custom_fields:
-          additionalProperties:
-            type: string
-          description: |
-            Merchant-defined custom field values keyed by Chargebee API name
-            (for example, `cf_po_number`). Values are serialized as strings.
-
-            Used as:
-            - `main_document.custom_fields` — invoice / credit note fields
-            - `accounting_customer_party.custom_fields` — customer fields
-            - `main_document.subscription_custom_fields` — subscription fields when the
-              document has a single subscription (set once at document level)
-            - `lines[].subscription_custom_fields` — subscription fields when the
-              document is consolidated / multi-subscription (resolved per line by Chargebee)
-            - `lines[].product_custom_fields` — product / item-price fields for the
-              product on that line (always line-level)
-
-            Adapter guidance for subscription fields:
-            - Prefer `lines[].subscription_custom_fields` when present on a line
-            - Otherwise use `document.subscription_custom_fields`
-
-            Examples: `document.custom_fields.cf_invoice_reference`,
-            `document.subscription_custom_fields.cf_contract_id`,
-            `lines[].subscription_custom_fields.cf_contract_id`,
-            `lines[].product_custom_fields.cf_hs_code`.
-          example:
-            cf_po_number: PO-12345
-            cf_cost_center: CC-42
-          type: object
+          allOf:
+          - $ref: '#/components/schemas/custom_fields'
+          description: Customer custom field values keyed by API name (e.g. `cf_tax_id`).
       required:
       - address
       - legalEntity
@@ -3026,63 +2935,17 @@ components:
             to the line.
           type: string
         subscription_custom_fields:
-          additionalProperties:
-            type: string
+          allOf:
+          - $ref: '#/components/schemas/custom_fields'
           description: |
-            Merchant-defined custom field values keyed by Chargebee API name
-            (for example, `cf_po_number`). Values are serialized as strings.
-
-            Used as:
-            - `main_document.custom_fields` — invoice / credit note fields
-            - `accounting_customer_party.custom_fields` — customer fields
-            - `main_document.subscription_custom_fields` — subscription fields when the
-              document has a single subscription (set once at document level)
-            - `lines[].subscription_custom_fields` — subscription fields when the
-              document is consolidated / multi-subscription (resolved per line by Chargebee)
-            - `lines[].product_custom_fields` — product / item-price fields for the
-              product on that line (always line-level)
-
-            Adapter guidance for subscription fields:
-            - Prefer `lines[].subscription_custom_fields` when present on a line
-            - Otherwise use `document.subscription_custom_fields`
-
-            Examples: `document.custom_fields.cf_invoice_reference`,
-            `document.subscription_custom_fields.cf_contract_id`,
-            `lines[].subscription_custom_fields.cf_contract_id`,
-            `lines[].product_custom_fields.cf_hs_code`.
-          example:
-            cf_po_number: PO-12345
-            cf_cost_center: CC-42
-          type: object
+            Subscription custom fields for this line's subscription.
+            Present on consolidated / multi-subscription documents.
+            For single-subscription documents, see `main_document.subscription_custom_fields`.
         product_custom_fields:
-          additionalProperties:
-            type: string
-          description: |
-            Merchant-defined custom field values keyed by Chargebee API name
-            (for example, `cf_po_number`). Values are serialized as strings.
-
-            Used as:
-            - `main_document.custom_fields` — invoice / credit note fields
-            - `accounting_customer_party.custom_fields` — customer fields
-            - `main_document.subscription_custom_fields` — subscription fields when the
-              document has a single subscription (set once at document level)
-            - `lines[].subscription_custom_fields` — subscription fields when the
-              document is consolidated / multi-subscription (resolved per line by Chargebee)
-            - `lines[].product_custom_fields` — product / item-price fields for the
-              product on that line (always line-level)
-
-            Adapter guidance for subscription fields:
-            - Prefer `lines[].subscription_custom_fields` when present on a line
-            - Otherwise use `document.subscription_custom_fields`
-
-            Examples: `document.custom_fields.cf_invoice_reference`,
-            `document.subscription_custom_fields.cf_contract_id`,
-            `lines[].subscription_custom_fields.cf_contract_id`,
-            `lines[].product_custom_fields.cf_hs_code`.
-          example:
-            cf_po_number: PO-12345
-            cf_cost_center: CC-42
-          type: object
+          allOf:
+          - $ref: '#/components/schemas/custom_fields'
+          description: Product / item-price custom field values for this line keyed
+            by API name (e.g. `cf_hs_code`).
         classified_tax_category:
           description: "List of tax categories applicable to the invoice line, such\
             \ as VAT or other indirect taxes."

--- a/spec/spi/openapi_einvoicing.yml
+++ b/spec/spi/openapi_einvoicing.yml
@@ -2042,6 +2042,10 @@ components:
           description: A textual note that gives unstructured information that is
             relevant to the Document as a whole. Such as the reason for any correction
             or assignment note in case the document has been factored.
+        custom_fields:
+          $ref: '#/components/schemas/custom_fields'
+        subscription_custom_fields:
+          $ref: '#/components/schemas/custom_fields'
         billing_reference:
           type: array
           description: A group of business terms providing information on one or more preceding invoices. This enhances traceability in workflows where a document is linked to earlier billing records. For credit notes this is essential as they must reference the original invoice they amend.
@@ -2104,6 +2108,8 @@ components:
             legal_entity:
               description: Legal entity of the customer party.
               $ref: '#/components/schemas/party_legal_entity'
+            custom_fields:
+              $ref: '#/components/schemas/custom_fields'
           required:
             - address
             - taxScheme
@@ -2142,6 +2148,10 @@ components:
                 type: string
                 description: The unique identifier (in Chargebee) of the product corresponding
                   to the line.
+              subscription_custom_fields:
+                $ref: '#/components/schemas/custom_fields'
+              product_custom_fields:
+                $ref: '#/components/schemas/custom_fields'
               classified_tax_category:
                 type: array
                 description: List of tax categories applicable to the invoice line,
@@ -2780,6 +2790,35 @@ components:
             the party as a legal entity or person.
       required:
         - registrationName
+    custom_fields:
+      type: object
+      description: |
+        Merchant-defined custom field values keyed by Chargebee API name
+        (for example, `cf_po_number`). Values are serialized as strings.
+
+        Used as:
+        - `main_document.custom_fields` — invoice / credit note fields
+        - `accounting_customer_party.custom_fields` — customer fields
+        - `main_document.subscription_custom_fields` — subscription fields when the
+          document has a single subscription (set once at document level)
+        - `lines[].subscription_custom_fields` — subscription fields when the
+          document is consolidated / multi-subscription (resolved per line by Chargebee)
+        - `lines[].product_custom_fields` — product / item-price fields for the
+          product on that line (always line-level)
+
+        Adapter guidance for subscription fields:
+        - Prefer `lines[].subscription_custom_fields` when present on a line
+        - Otherwise use `document.subscription_custom_fields`
+
+        Examples: `document.custom_fields.cf_invoice_reference`,
+        `document.subscription_custom_fields.cf_contract_id`,
+        `lines[].subscription_custom_fields.cf_contract_id`,
+        `lines[].product_custom_fields.cf_hs_code`.
+      additionalProperties:
+        type: string
+      example:
+        cf_po_number: "PO-12345"
+        cf_cost_center: "CC-42"
     callback_document_status:
       type: object
       properties:

--- a/spec/spi/openapi_einvoicing.yml
+++ b/spec/spi/openapi_einvoicing.yml
@@ -2043,9 +2043,15 @@ components:
             relevant to the Document as a whole. Such as the reason for any correction
             or assignment note in case the document has been factored.
         custom_fields:
-          $ref: '#/components/schemas/custom_fields'
+          description: Invoice or credit note custom field values keyed by API name (e.g. `cf_invoice_reference`).
+          allOf:
+            - $ref: '#/components/schemas/custom_fields'
         subscription_custom_fields:
-          $ref: '#/components/schemas/custom_fields'
+          description: |
+            Subscription custom fields for single-subscription documents (set once at document level).
+            For consolidated / multi-subscription documents, use `lines[].subscription_custom_fields` instead.
+          allOf:
+            - $ref: '#/components/schemas/custom_fields'
         billing_reference:
           type: array
           description: A group of business terms providing information on one or more preceding invoices. This enhances traceability in workflows where a document is linked to earlier billing records. For credit notes this is essential as they must reference the original invoice they amend.
@@ -2109,7 +2115,9 @@ components:
               description: Legal entity of the customer party.
               $ref: '#/components/schemas/party_legal_entity'
             custom_fields:
-              $ref: '#/components/schemas/custom_fields'
+              description: Customer custom field values keyed by API name (e.g. `cf_tax_id`).
+              allOf:
+                - $ref: '#/components/schemas/custom_fields'
           required:
             - address
             - taxScheme
@@ -2149,9 +2157,16 @@ components:
                 description: The unique identifier (in Chargebee) of the product corresponding
                   to the line.
               subscription_custom_fields:
-                $ref: '#/components/schemas/custom_fields'
+                description: |
+                  Subscription custom fields for this line's subscription.
+                  Present on consolidated / multi-subscription documents.
+                  For single-subscription documents, see `main_document.subscription_custom_fields`.
+                allOf:
+                  - $ref: '#/components/schemas/custom_fields'
               product_custom_fields:
-                $ref: '#/components/schemas/custom_fields'
+                description: Product / item-price custom field values for this line keyed by API name (e.g. `cf_hs_code`).
+                allOf:
+                  - $ref: '#/components/schemas/custom_fields'
               classified_tax_category:
                 type: array
                 description: List of tax categories applicable to the invoice line,
@@ -2795,25 +2810,6 @@ components:
       description: |
         Merchant-defined custom field values keyed by Chargebee API name
         (for example, `cf_po_number`). Values are serialized as strings.
-
-        Used as:
-        - `main_document.custom_fields` — invoice / credit note fields
-        - `accounting_customer_party.custom_fields` — customer fields
-        - `main_document.subscription_custom_fields` — subscription fields when the
-          document has a single subscription (set once at document level)
-        - `lines[].subscription_custom_fields` — subscription fields when the
-          document is consolidated / multi-subscription (resolved per line by Chargebee)
-        - `lines[].product_custom_fields` — product / item-price fields for the
-          product on that line (always line-level)
-
-        Adapter guidance for subscription fields:
-        - Prefer `lines[].subscription_custom_fields` when present on a line
-        - Otherwise use `document.subscription_custom_fields`
-
-        Examples: `document.custom_fields.cf_invoice_reference`,
-        `document.subscription_custom_fields.cf_contract_id`,
-        `lines[].subscription_custom_fields.cf_contract_id`,
-        `lines[].product_custom_fields.cf_hs_code`.
       additionalProperties:
         type: string
       example:


### PR DESCRIPTION
## CHANGELOG
Added reusable `custom_fields` support to the e-invoicing SPI document submission schema for customer, document (invoice/credit note), subscription, and product custom fields.

## SUMMARY
Extends `openapi_einvoicing.yml` so Chargebee custom fields can be passed on document submission:
- `main_document.custom_fields` — invoice / credit note fields
- `accounting_customer_party.custom_fields` — customer fields
- `main_document.subscription_custom_fields` — single-subscription documents
- `lines[].subscription_custom_fields` — multi-subscription / consolidated documents
- `lines[].product_custom_fields` — product / item-price fields

Custom fields are represented as string-keyed maps (`api_name` → string value), e.g. `cf_po_number`.

## FUNCTIONAL AUTOMATION CHANGES PR
- [ ] Yes
  - If Yes, PR :
- [x] No
  - If No, Reason: SPI OpenAPI contract change only; no functional automation impacted

## AUTOMATION TEST REPORT URL
N/A

## AREAS OF IMPACT
E-invoicing SPI document submission contract (`main_document` / adapter payload shape). Downstream consumers: third-party e-invoicing adapters and chargebee-app transformers that populate this SPI.

## TYPE OF CHANGE
- [ ] 🐞 Bugfix
- [x] 🌟 Feature
- [ ] ✨ Enhancement
- [ ] 🧪 Unit Test Cases
- [ ] 📔 Documentation
- [ ] ⚙️ Chore - Build Related / Configuration / Others

## DOCUMENTATION
N/A — schema documented in `spec/spi/openapi_einvoicing.yml` (`custom_fields` component and usages)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds reusable `custom_fields` support to the e-invoicing SPI OpenAPI schema. Document, customer, subscription, product, and line-item contexts now accept string-keyed custom field maps through new optional properties and a shared `custom_fields` component schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->