### PR TITLE
Dev

### DIFF
--- a/spec/spi/generated/einvoicing/api/openapi.yaml
+++ b/spec/spi/generated/einvoicing/api/openapi.yaml
@@ -2028,9 +2028,9 @@ components:
           format: date
           type: string
         sender_party:
-          $ref: '#/components/schemas/application_response_document_sender_party'
+          $ref: '#/components/schemas/application_response_party'
         receiver_party:
-          $ref: '#/components/schemas/application_response_document_receiver_party'
+          $ref: '#/components/schemas/application_response_party'
         document_response:
           $ref: '#/components/schemas/application_response_document_document_response'
         overrides:
@@ -2318,6 +2318,18 @@ components:
       - REFUND_DUE
       example: PAYMENT_DUE
       type: string
+    application_response_party:
+      description: Party information for the sender or receiver of an application
+        response document.
+      properties:
+        name:
+          description: Name of the party.
+          type: string
+        tax_registration_number:
+          description: "Tax registration number of the party (for example VAT / GST\
+            \ number), when available."
+          type: string
+      type: object
     address:
       properties:
         line_1:
@@ -2919,26 +2931,6 @@ components:
           items:
             $ref: '#/components/schemas/main_document_tax_total_tax_sub_totals_inner'
           type: array
-      type: object
-    application_response_document_sender_party:
-      properties:
-        name:
-          description: Name of the sender party.
-          type: string
-        tax_registration_number:
-          description: "Tax registration number of the sender (for example VAT / GST\
-            \ number), when available."
-          type: string
-      type: object
-    application_response_document_receiver_party:
-      properties:
-        name:
-          description: Name of the receiver party.
-          type: string
-        tax_registration_number:
-          description: "Tax registration number of the receiver (for example VAT /\
-            \ GST number), when available."
-          type: string
       type: object
     application_response_document_document_response_response:
       properties:

--- a/spec/spi/generated/einvoicing/api/openapi.yaml
+++ b/spec/spi/generated/einvoicing/api/openapi.yaml
@@ -1938,6 +1938,17 @@ components:
             relevant to the Document as a whole. Such as the reason for any correction
             or assignment note in case the document has been factored.
           type: string
+        custom_fields:
+          allOf:
+          - $ref: '#/components/schemas/custom_fields'
+          description: Invoice or credit note custom field values keyed by API name
+            (e.g. `cf_invoice_reference`).
+        subscription_custom_fields:
+          allOf:
+          - $ref: '#/components/schemas/custom_fields'
+          description: |
+            Subscription custom fields for single-subscription documents (set once at document level).
+            For consolidated / multi-subscription documents, use `lines[].subscription_custom_fields` instead.
         billing_reference:
           description: A group of business terms providing information on one or more
             preceding invoices. This enhances traceability in workflows where a document
@@ -2330,6 +2341,16 @@ components:
         country:
           description: ISO 3166-1 alpha-2 country code.
           type: string
+      type: object
+    custom_fields:
+      additionalProperties:
+        type: string
+      description: |
+        Merchant-defined custom field values keyed by Chargebee API name
+        (for example, `cf_po_number`). Values are serialized as strings.
+      example:
+        cf_po_number: PO-12345
+        cf_cost_center: CC-42
       type: object
     callback_document_status:
       properties:
@@ -2794,6 +2815,10 @@ components:
           description: "Tax registration number of the customer (for example VAT /\
             \ GST number), when available."
           type: string
+        custom_fields:
+          allOf:
+          - $ref: '#/components/schemas/custom_fields'
+          description: Customer custom field values keyed by API name (e.g. `cf_tax_id`).
       required:
       - address
       type: object
@@ -2836,6 +2861,18 @@ components:
           description: The unique identifier (in Chargebee) of the product corresponding
             to the line.
           type: string
+        subscription_custom_fields:
+          allOf:
+          - $ref: '#/components/schemas/custom_fields'
+          description: |
+            Subscription custom fields for this line's subscription.
+            Present on consolidated / multi-subscription documents.
+            For single-subscription documents, see `main_document.subscription_custom_fields`.
+        product_custom_fields:
+          allOf:
+          - $ref: '#/components/schemas/custom_fields'
+          description: Product / item-price custom field values for this line keyed
+            by API name (e.g. `cf_hs_code`).
         classified_tax_category:
           description: "List of tax categories applicable to the invoice line, such\
             \ as VAT or other indirect taxes."

--- a/spec/spi/generated/einvoicing/api/openapi.yaml
+++ b/spec/spi/generated/einvoicing/api/openapi.yaml
@@ -631,8 +631,8 @@ paths:
           \    {\n          \"target\": \"Invoice.cac:AccountingCustomerParty.cac:Party.cac:PostalAddress.cac:Country.cbc:IdentificationCode\"\
           ,\n          \"source\": \"customer.billing_address.country\"\n        },\n\
           \        {\n          \"target\": \"Invoice.cac:AccountingCustomerParty.cac:Party.cac:PartyIdentification.cbc:ID.@schemeID\\\
-          \"\",\n          \"source\": \"customer.cf_einvoice_scheme_id\"\n      \
-          \  },\n        {\n          \"target\": \"Invoice.cac:TaxTotal.cbc:TaxAmount\"\
+          \"\",\n          \"source\": \"custom_fields[cf_einvoice_scheme_id]\"\n\
+          \        },\n        {\n          \"target\": \"Invoice.cac:TaxTotal.cbc:TaxAmount\"\
           ,\n          \"source\": \"invoice.tax_total\"\n        },\n        {\n\
           \          \"target\": \"Invoice.cbc:Note\",\n          \"source\": \"invoice.note\"\
           \n        },\n        {\n          \"target\": \"Invoice.cac:InvoiceLine.cbc:ID\"\
@@ -667,21 +667,21 @@ paths:
           : \"EUR\",\n        \"invoice.due_date\": \"2025-04-30\",\n        \"invoice.amount\"\
           : 114.0,\n        \"invoice.note\": \"Payment due in 28 days.\",\n     \
           \   \"business.address.country\": \"DE\",\n        \"customer.billing_address.country\"\
-          : \"DE\",\n        \"invoice.tax_total\": 14.0,\n        \"line_items\"\
-          : [\n          {\n            \"id\": \"1\",\n            \"description\"\
-          : \"Consulting Services - April\",\n            \"quantity\": 1,\n     \
-          \       \"unit_price\": 100.0,\n            \"amount\": 100.0,\n       \
-          \     \"item_code\": \"CONS-APRIL\",\n            \"tax_rate\" : \"14\"\
+          : \"DE\",\n        \"custom_fields[cf_einvoice_scheme_id]\": \"9930\",\n\
+          \        \"invoice.tax_total\": 14.0,\n        \"line_items\": [\n     \
+          \     {\n            \"id\": \"1\",\n            \"description\": \"Consulting\
+          \ Services - April\",\n            \"quantity\": 1,\n            \"unit_price\"\
+          : 100.0,\n            \"amount\": 100.0,\n            \"item_code\": \"\
+          CONS-APRIL\",\n            \"tax_rate\" : \"14\",\n            \"classified_tax_category\"\
+          : {\n              \"percentage\": 14,\n              \"category\": \"VAT\"\
+          ,\n              \"country\": \"DE\"\n            }\n          },\n    \
+          \      {\n            \"id\": \"2\",\n            \"description\": \"TEST\
+          \ Consulting Services - April\",\n            \"quantity\": 130,\n     \
+          \       \"unit_price\": 1000.0,\n            \"amount\": 1005.0,\n     \
+          \       \"item_code\": \"CONS-APRIL\",\n            \"tax_rate\" : \"30\"\
           ,\n            \"classified_tax_category\": {\n              \"percentage\"\
-          : 14,\n              \"category\": \"VAT\",\n              \"country\":\
-          \ \"DE\"\n            }\n          },\n          {\n            \"id\":\
-          \ \"2\",\n            \"description\": \"TEST Consulting Services - April\"\
-          ,\n            \"quantity\": 130,\n            \"unit_price\": 1000.0,\n\
-          \            \"amount\": 1005.0,\n            \"item_code\": \"CONS-APRIL\"\
-          ,\n            \"tax_rate\" : \"30\",\n            \"classified_tax_category\"\
-          : {\n              \"percentage\": 30,\n              \"category\": \"EU\
-          \ VAT\",\n              \"country\": \"DE\"\n            }\n          }\n\
-          \        ]\n      }\n    }\n  }'\n"
+          : 30,\n              \"category\": \"EU VAT\",\n              \"country\"\
+          : \"DE\"\n            }\n          }\n        ]\n      }\n    }\n  }'\n"
       - lang: cURL
         label: Credit note document submission
         source: |
@@ -816,20 +816,20 @@ paths:
           \ has(e.responseKey) && e.responseKey == 'Receipt Message ID') ? invoiceResponse.events.filter(e,\
           \ has(e.responseKey) && e.responseKey == 'Receipt Message ID').map(e, e.responseValue)[0]\
           \ : null\"\n        },\n        {\n          \"target\": \"Creditnote.cac:AccountingSupplierParty.cac:Party.cbc:EndpointID\"\
-          ,\n          \"source\": \"business.legal_entity.company_id\"\n        },\n\
-          \        {\n          \"target\": \"Creditnote.cac:AccountingSupplierParty.cac:Party.cac:PostalAddress.cac:Country.cbc:IdentificationCode\"\
+          ,\n          \"source\": \"tax_reg_number\"\n        },\n        {\n   \
+          \       \"target\": \"Creditnote.cac:AccountingSupplierParty.cac:Party.cac:PostalAddress.cac:Country.cbc:IdentificationCode\"\
           ,\n          \"source\": \"business.address.country\"\n        },\n    \
           \    {\n          \"target\": \"Creditnote.cac:AccountingSupplierParty.cac:Party.cac:PartyLegalEntity.cbc:RegistrationName\"\
-          ,\n          \"source\": \"business.legal_entity.registration_name\"\n \
-          \       },\n        {\n          \"target\": \"Creditnote.cac:AccountingCustomerParty.cac:Party.cbc:EndpointID\"\
-          ,\n          \"source\": \"customer.legal_entity.company_id\"\n        },\n\
-          \        {\n          \"target\": \"Creditnote.cac:AccountingCustomerParty.cac:Party.cac:PostalAddress.cac:Country.cbc:IdentificationCode\"\
+          ,\n          \"source\": \"organization_details.organization_name\"\n  \
+          \      },\n        {\n          \"target\": \"Creditnote.cac:AccountingCustomerParty.cac:Party.cbc:EndpointID\"\
+          ,\n          \"source\": \"customer.vat_number\"\n        },\n        {\n\
+          \          \"target\": \"Creditnote.cac:AccountingCustomerParty.cac:Party.cac:PostalAddress.cac:Country.cbc:IdentificationCode\"\
           ,\n          \"source\": \"customer.billing_address.country\"\n        },\n\
           \        {\n          \"target\": \"Creditnote.cac:AccountingCustomerParty.cac:Party.cac:PartyLegalEntity.cbc:RegistrationName\"\
-          ,\n          \"source\": \"customer.legal_entity.registration_name\"\n \
-          \       },\n        {\n          \"target\": \"Invoice.cac:AccountingCustomerParty.cac:Party.cac:PartyIdentification.cbc:ID.@schemeID\\\
-          \"\",\n          \"source\": \"customer.cf_einvoice_scheme_id\"\n      \
-          \  },\n        {\n          \"target\": \"Creditnote.cac:TaxTotal.cbc:TaxAmount\"\
+          ,\n          \"source\": \"customer.company\"\n        },\n        {\n \
+          \         \"target\": \"Invoice.cac:AccountingCustomerParty.cac:Party.cac:PartyIdentification.cbc:ID.@schemeID\\\
+          \"\",\n          \"source\": \"custom_fields[cf_einvoice_scheme_id]\"\n\
+          \        },\n        {\n          \"target\": \"Creditnote.cac:TaxTotal.cbc:TaxAmount\"\
           ,\n          \"source\": \"credit_note.tax_total\"\n        },\n       \
           \ {\n          \"target\": \"Creditnote.cac:TaxTotal.cbc:TaxAmount.@currencyID\"\
           ,\n          \"source\": \"credit_note.currency_code\"\n        },\n   \
@@ -864,12 +864,12 @@ paths:
           : {\n          \"invoice_document_reference\": {\n            \"id\": \"\
           INV-10001\",\n            \"issue_date\": \"2025-04-02\"\n          }\n\
           \        },\n        \"credit_note.note\": \"Refund for April invoice\"\
-          ,\n        \"business.address.country\": \"DE\",\n        \"business.legal_entity.company_id\"\
-          : \"987654321\",\n        \"business.legal_entity.registration_name\": \"\
-          Example Seller GmbH\",\n        \"customer.billing_address.country\": \"\
-          DE\",\n        \"customer.legal_entity.company_id\": \"123456789\",\n  \
-          \      \"customer.legal_entity.registration_name\": \"Example Buyer GmbH\"\
-          ,\n        \"credit_note.tax_total\": 40.0,\n        \"invoiceResponse\"\
+          ,\n        \"business.address.country\": \"DE\",\n        \"tax_reg_number\"\
+          : \"DE987654321\",\n        \"organization_details.organization_name\":\
+          \ \"Example Seller GmbH\",\n        \"customer.billing_address.country\"\
+          : \"DE\",\n        \"customer.vat_number\": \"DE123456789\",\n        \"\
+          customer.company\": \"Example Buyer GmbH\",\n        \"custom_fields[cf_einvoice_scheme_id]\"\
+          : \"9930\",\n        \"credit_note.tax_total\": 40.0,\n        \"invoiceResponse\"\
           : {\n        \"events\": [\n          {\n            \"responseKey\": \"\
           Some Other Event\",\n            \"responseValue\": \"Some Value\"\n   \
           \       },\n          {\n            \"responseKey\": \"Receipt Message\
@@ -905,16 +905,12 @@ paths:
               "document_type": "ubl-applicationresponse",
               "issue_date": "2025-04-04",
               "sender_party": {
-                "legal_entity": {
-                  "registration_name": "Example Sender GmbH",
-                  "company_id": "DE998877665"
-                }
+                "name": "Example Sender GmbH",
+                "tax_registration_number": "DE987654321"
               },
               "receiver_party": {
-                "legal_entity": {
-                  "registration_name": "Example Receiver GmbH",
-                  "company_id": "DE112233445"
-                }
+                "name": "Example Receiver GmbH",
+                "tax_registration_number": "DE123456789"
               },
               "document_response": {
                 "response": {
@@ -942,16 +938,12 @@ paths:
               "document_type": "ubl-applicationresponse",
               "issue_date": "2025-04-03",
               "sender_party": {
-                "legal_entity": {
-                  "registration_name": "Example Sender GmbH",
-                  "company_id": "DE123456789"
-                }
+                "name": "Example Sender GmbH",
+                "tax_registration_number": "DE987654321"
               },
               "receiver_party": {
-                "legal_entity": {
-                  "registration_name": "Example Receiver GmbH",
-                  "company_id": "DE987654321"
-                }
+                "name": "Example Receiver GmbH",
+                "tax_registration_number": "DE123456789"
               },
               "document_response": {
                 "response": {
@@ -978,11 +970,11 @@ paths:
                   },
                   {
                     "target": "ApplicationResponse.cac:SenderParty.cac:PartyLegalEntity.cbc:RegistrationName",
-                    "source": "application_response.sender_party.legal_entity.registration_name"
+                    "source": "application_response.sender_party.name"
                   },
                   {
                     "target": "ApplicationResponse.cac:ReceiverParty.cac:PartyLegalEntity.cbc:RegistrationName",
-                    "source": "application_response.receiver_party.legal_entity.registration_name"
+                    "source": "application_response.receiver_party.name"
                   },
                   {
                     "target": "ApplicationResponse.cac:DocumentResponse.cac:Response.cbc:ResponseCode",
@@ -1000,8 +992,8 @@ paths:
                 "values": {
                   "application_response.id": "APPRESP-20240401-001",
                   "application_response.issue_date": "2025-04-03",
-                  "application_response.sender_party.legal_entity.registration_name": "Example Sender GmbH",
-                  "application_response.receiver_party.legal_entity.registration_name": "Example Receiver GmbH",
+                  "application_response.sender_party.name": "Example Sender GmbH",
+                  "application_response.receiver_party.name": "Example Receiver GmbH",
                   "application_response.document_response.response.status": "Accepted",
                   "application_response.document_response.response.note": "Invoice accepted without issues",
                   "application_response.document_response.document_reference.id": "INV-20240330-567"
@@ -2027,7 +2019,7 @@ components:
         sender_party:
           $ref: '#/components/schemas/application_response_document_sender_party'
         receiver_party:
-          $ref: '#/components/schemas/application_response_document_sender_party'
+          $ref: '#/components/schemas/application_response_document_receiver_party'
         document_response:
           $ref: '#/components/schemas/application_response_document_document_response'
         overrides:
@@ -2338,19 +2330,6 @@ components:
         country:
           description: ISO 3166-1 alpha-2 country code.
           type: string
-      type: object
-    party_legal_entity:
-      description: Legal entity information of the party.
-      properties:
-        registration_name:
-          description: The full formal name by which the party is registered.
-          type: string
-        company_id:
-          description: An identifier issued by an official registrar that identifies
-            the party as a legal entity or person.
-          type: string
-      required:
-      - registrationName
       type: object
     callback_document_status:
       properties:
@@ -2906,10 +2885,23 @@ components:
       type: object
     application_response_document_sender_party:
       properties:
-        legal_entity:
-          $ref: '#/components/schemas/party_legal_entity'
-      required:
-      - legal_entity
+        name:
+          description: Name of the sender party.
+          type: string
+        tax_registration_number:
+          description: "Tax registration number of the sender (for example VAT / GST\
+            \ number), when available."
+          type: string
+      type: object
+    application_response_document_receiver_party:
+      properties:
+        name:
+          description: Name of the receiver party.
+          type: string
+        tax_registration_number:
+          description: "Tax registration number of the receiver (for example VAT /\
+            \ GST number), when available."
+          type: string
       type: object
     application_response_document_document_response_response:
       properties:

--- a/spec/spi/generated/einvoicing/api/openapi.yaml
+++ b/spec/spi/generated/einvoicing/api/openapi.yaml
@@ -528,12 +528,7 @@ paths:
                   "city": "Cologne",
                   "country": "DE"
                 },
-                "tax_scheme": [
-                  {
-                    "scheme": "VAT",
-                    "id": "DE987654321"
-                  }
-                ]
+                "tax_registration_number": "DE987654321"
               },
               "accounting_customer_party": {
                 "name": "Example Buyer GmbH",
@@ -544,12 +539,7 @@ paths:
                   "city": "Berlin",
                   "country": "DE"
                 },
-                "tax_scheme": [
-                  {
-                    "scheme": "VAT",
-                    "id": "DE123456789"
-                  }
-                ]
+                "tax_registration_number": "DE123456789"
               },
               "payment_means": [
                 {
@@ -607,32 +597,30 @@ paths:
           : {\n      \"name\": \"Example Seller GmbH\",\n      \"address\": {\n  \
           \      \"line_1\": \"Hauptstr. 456\",\n        \"line_2\": \"Suite 5\",\n\
           \        \"zip\": \"50667\",\n        \"city\": \"Cologne\",\n        \"\
-          country\": \"DE\"\n      },\n      \"tax_scheme\": [\n        {\n      \
-          \    \"scheme\": \"VAT\",\n          \"id\": \"DE987654321\"\n        }\n\
-          \      ]\n    },\n    \"accounting_customer_party\": {\n      \"name\":\
-          \ \"Example Buyer GmbH\",\n      \"address\": {\n        \"line_1\": \"\
-          Berliner Str. 123\",\n        \"line_2\": \"2nd Floor\",\n        \"zip\"\
-          : \"10115\",\n        \"city\": \"Berlin\",\n        \"country\": \"DE\"\
-          \n      },\n      \"tax_scheme\": [\n        {\n          \"scheme\": \"\
-          VAT\",\n          \"id\": \"DE123456789\"\n        }\n      ]\n    },\n\
-          \    \"payment_means\": [\n      {\n        \"code\": \"ONLINE_PAYMENT_SERVICE\"\
-          ,\n        \"payment_id\": \"PAY-2024-00987\",\n        \"card_account\"\
-          : {\n          \"primary_account_number_id\": \"4111********1111\",\n  \
-          \        \"card_holder_name\": \"Jane Smith\",\n          \"network_id\"\
-          : \"MASTERCARD\"\n        }\n      }\n    ],\n    \"lines\": [\n      {\n\
-          \        \"id\": \"1\",\n        \"description\": \"Consulting Services\
-          \ - April\",\n        \"quantity\": 1,\n        \"unit_price\": 100.0,\n\
-          \        \"amount\": 100.0,\n        \"item_code\": \"CONS-APRIL\",\n  \
-          \      \"classified_tax_category\": [\n          {\n            \"percentage\"\
-          : 14,\n            \"category\": \"VAT\",\n            \"country\": \"DE\"\
-          \n          }\n        ]\n      }\n    ],\n    \"tax_total\": {\n      \"\
-          tax_amount\": 14.0,\n      \"tax_sub_totals\": [\n        {\n          \"\
-          taxable_amount\": 100.0,\n          \"tax_amount\": 14.0,\n          \"\
-          percentage\": 14,\n          \"country\": \"DE\",\n          \"category\"\
-          : \"VAT\"\n        }\n      ]\n    },\n    \"overrides\": {\n      \"country\"\
-          : \"DE\", \n      \"transaction_type\": \"B2B\",\n      \"model\": \"PEPPOL\"\
-          ,\n      \"document_type\": \"ubl-invoice\",\n      \"field_mapping\": [\n\
-          \        {\n          \"target\": \"Invoice.cbc:ID\",\n          \"source\"\
+          country\": \"DE\"\n      },\n      \"tax_registration_number\": \"DE987654321\"\
+          \n    },\n    \"accounting_customer_party\": {\n      \"name\": \"Example\
+          \ Buyer GmbH\",\n      \"address\": {\n        \"line_1\": \"Berliner Str.\
+          \ 123\",\n        \"line_2\": \"2nd Floor\",\n        \"zip\": \"10115\"\
+          ,\n        \"city\": \"Berlin\",\n        \"country\": \"DE\"\n      },\n\
+          \      \"tax_registration_number\": \"DE123456789\"\n    },\n    \"payment_means\"\
+          : [\n      {\n        \"code\": \"ONLINE_PAYMENT_SERVICE\",\n        \"\
+          payment_id\": \"PAY-2024-00987\",\n        \"card_account\": {\n       \
+          \   \"primary_account_number_id\": \"4111********1111\",\n          \"card_holder_name\"\
+          : \"Jane Smith\",\n          \"network_id\": \"MASTERCARD\"\n        }\n\
+          \      }\n    ],\n    \"lines\": [\n      {\n        \"id\": \"1\",\n  \
+          \      \"description\": \"Consulting Services - April\",\n        \"quantity\"\
+          : 1,\n        \"unit_price\": 100.0,\n        \"amount\": 100.0,\n     \
+          \   \"item_code\": \"CONS-APRIL\",\n        \"classified_tax_category\"\
+          : [\n          {\n            \"percentage\": 14,\n            \"category\"\
+          : \"VAT\",\n            \"country\": \"DE\"\n          }\n        ]\n  \
+          \    }\n    ],\n    \"tax_total\": {\n      \"tax_amount\": 14.0,\n    \
+          \  \"tax_sub_totals\": [\n        {\n          \"taxable_amount\": 100.0,\n\
+          \          \"tax_amount\": 14.0,\n          \"percentage\": 14,\n      \
+          \    \"country\": \"DE\",\n          \"category\": \"VAT\"\n        }\n\
+          \      ]\n    },\n    \"overrides\": {\n      \"country\": \"DE\", \n  \
+          \    \"transaction_type\": \"B2B\",\n      \"model\": \"PEPPOL\",\n    \
+          \  \"document_type\": \"ubl-invoice\",\n      \"field_mapping\": [\n   \
+          \     {\n          \"target\": \"Invoice.cbc:ID\",\n          \"source\"\
           : \"invoice.id\"\n        },\n        {\n          \"target\": \"Invoice.cbc:IssueDate\"\
           ,\n          \"source\": \"invoice.issue_date\"\n        },\n        {\n\
           \          \"target\": \"Invoice.cbc:InvoiceTypeCode\",\n          \"fixed_value\"\
@@ -726,12 +714,7 @@ paths:
                   "city": "Cologne",
                   "country": "DE"
                 },
-                "tax_scheme": [
-                  {
-                    "scheme": "VAT",
-                    "id": "DE987654321"
-                  }
-                ]
+                "tax_registration_number": "DE987654321"
               },
               "accounting_customer_party": {
                 "name": "Example Buyer GmbH",
@@ -742,12 +725,7 @@ paths:
                   "city": "Berlin",
                   "country": "DE"
                 },
-                "tax_scheme": [
-                  {
-                    "scheme": "VAT",
-                    "id": "DE123456789"
-                  }
-                ]
+                "tax_registration_number": "DE123456789"
               },
               "payment_means": [
                 {
@@ -805,22 +783,20 @@ paths:
           \ GmbH\",\n      \"address\": {\n        \"line_1\": \"Hauptstr. 456\",\n\
           \        \"line_2\": \"Suite 5\",\n        \"zip\": \"50667\",\n       \
           \ \"city\": \"Cologne\",\n        \"country\": \"DE\"\n      },\n      \"\
-          tax_scheme\": [\n        {\n          \"scheme\": \"VAT\",\n          \"\
-          id\": \"DE987654321\"\n        }\n      ]\n    },\n    \"accounting_customer_party\"\
+          tax_registration_number\": \"DE987654321\"\n    },\n    \"accounting_customer_party\"\
           : {\n      \"name\": \"Example Buyer GmbH\",\n      \"address\": {\n   \
           \     \"line_1\": \"Berliner Str. 123\",\n        \"line_2\": \"2nd Floor\"\
           ,\n        \"zip\": \"10115\",\n        \"city\": \"Berlin\",\n        \"\
-          country\": \"DE\"\n      },\n      \"tax_scheme\": [\n        {\n      \
-          \    \"scheme\": \"VAT\",\n          \"id\": \"DE123456789\"\n        }\n\
-          \      ]\n    },\n    \"payment_means\": [\n      {\n        \"code\": \"\
-          ONLINE_PAYMENT_SERVICE\",\n        \"payment_id\": \"PAY-2024-01002\",\n\
-          \        \"card_account\": {\n          \"primary_account_number_id\": \"\
-          4111********2222\",\n          \"card_holder_name\": \"John Doe\",\n   \
-          \       \"network_id\": \"VISA\"\n        }\n      }\n    ],\n    \"lines\"\
-          : [\n      {\n        \"id\": \"1\",\n        \"description\": \"Refund\
-          \ for overcharge in April\",\n        \"quantity\": 1,\n        \"unit_price\"\
-          : 50.0,\n        \"amount\": 50.0,\n        \"item_code\": \"APRIL-REFUND\"\
-          ,\n        \"classified_tax_category\": [\n          {\n            \"percentage\"\
+          country\": \"DE\"\n      },\n      \"tax_registration_number\": \"DE123456789\"\
+          \n    },\n    \"payment_means\": [\n      {\n        \"code\": \"ONLINE_PAYMENT_SERVICE\"\
+          ,\n        \"payment_id\": \"PAY-2024-01002\",\n        \"card_account\"\
+          : {\n          \"primary_account_number_id\": \"4111********2222\",\n  \
+          \        \"card_holder_name\": \"John Doe\",\n          \"network_id\":\
+          \ \"VISA\"\n        }\n      }\n    ],\n    \"lines\": [\n      {\n    \
+          \    \"id\": \"1\",\n        \"description\": \"Refund for overcharge in\
+          \ April\",\n        \"quantity\": 1,\n        \"unit_price\": 50.0,\n  \
+          \      \"amount\": 50.0,\n        \"item_code\": \"APRIL-REFUND\",\n   \
+          \     \"classified_tax_category\": [\n          {\n            \"percentage\"\
           : 14,\n            \"category\": \"VAT\",\n            \"country\": \"DE\"\
           \n          }\n        ]\n      }\n    ],\n    \"tax_total\": {\n      \"\
           tax_amount\": 7.0,\n      \"tax_sub_totals\": [\n        {\n          \"\
@@ -2363,24 +2339,6 @@ components:
           description: ISO 3166-1 alpha-2 country code.
           type: string
       type: object
-    tax_scheme:
-      properties:
-        scheme:
-          description: "A code identifying the tax regime under which this party is\
-            \ registered—such as VAT, GST, or a region-specific tax scheme. This enables\
-            \ the adapter or e‑invoicing provider to apply the correct tax logic or\
-            \ reporting rules."
-          type: string
-        id:
-          description: "The tax identification number assigned to the party by the\
-            \ relevant authority (for example, VAT number or legal registration ID).\
-            \ It is used for official identification and compliance in the e‑invoicing\
-            \ process."
-          type: string
-      required:
-      - id
-      - scheme
-      type: object
     party_legal_entity:
       description: Legal entity information of the party.
       properties:
@@ -2838,17 +2796,12 @@ components:
           type: string
         address:
           $ref: '#/components/schemas/address'
-        tax_scheme:
-          description: List of tax identifiers associated with the supplier.
-          items:
-            $ref: '#/components/schemas/tax_scheme'
-          type: array
-        legal_entity:
-          $ref: '#/components/schemas/party_legal_entity'
+        tax_registration_number:
+          description: "Tax registration number of the supplier (for example VAT /\
+            \ GST number), when available."
+          type: string
       required:
       - address
-      - legalEntity
-      - taxScheme
       type: object
     main_document_accounting_customer_party:
       description: "Party responsible for receiving the invoice (i.e., the customer)."
@@ -2858,17 +2811,12 @@ components:
           type: string
         address:
           $ref: '#/components/schemas/address'
-        tax_scheme:
-          description: List of tax identifiers associated.
-          items:
-            $ref: '#/components/schemas/tax_scheme'
-          type: array
-        legal_entity:
-          $ref: '#/components/schemas/party_legal_entity'
+        tax_registration_number:
+          description: "Tax registration number of the customer (for example VAT /\
+            \ GST number), when available."
+          type: string
       required:
       - address
-      - legalEntity
-      - taxScheme
       type: object
     main_document_lines_inner_classified_tax_category_inner:
       properties:

--- a/spec/spi/openapi_einvoicing.yml
+++ b/spec/spi/openapi_einvoicing.yml
@@ -388,12 +388,7 @@ paths:
                     "city": "Cologne",
                     "country": "DE"
                   },
-                  "tax_scheme": [
-                    {
-                      "scheme": "VAT",
-                      "id": "DE987654321"
-                    }
-                  ]
+                  "tax_registration_number": "DE987654321"
                 },
                 "accounting_customer_party": {
                   "name": "Example Buyer GmbH",
@@ -404,12 +399,7 @@ paths:
                     "city": "Berlin",
                     "country": "DE"
                   },
-                  "tax_scheme": [
-                    {
-                      "scheme": "VAT",
-                      "id": "DE123456789"
-                    }
-                  ]
+                  "tax_registration_number": "DE123456789"
                 },
                 "payment_means": [
                   {
@@ -486,12 +476,7 @@ paths:
                     "city": "Cologne",
                     "country": "DE"
                   },
-                  "tax_scheme": [
-                    {
-                      "scheme": "VAT",
-                      "id": "DE987654321"
-                    }
-                  ]
+                  "tax_registration_number": "DE987654321"
                 },
                 "accounting_customer_party": {
                   "name": "Example Buyer GmbH",
@@ -502,12 +487,7 @@ paths:
                     "city": "Berlin",
                     "country": "DE"
                   },
-                  "tax_scheme": [
-                    {
-                      "scheme": "VAT",
-                      "id": "DE123456789"
-                    }
-                  ]
+                  "tax_registration_number": "DE123456789"
                 },
                 "payment_means": [
                   {
@@ -717,12 +697,7 @@ paths:
                     "city": "Cologne",
                     "country": "DE"
                   },
-                  "tax_scheme": [
-                    {
-                      "scheme": "VAT",
-                      "id": "DE987654321"
-                    }
-                  ]
+                  "tax_registration_number": "DE987654321"
                 },
                 "accounting_customer_party": {
                   "name": "Example Buyer GmbH",
@@ -733,12 +708,7 @@ paths:
                     "city": "Berlin",
                     "country": "DE"
                   },
-                  "tax_scheme": [
-                    {
-                      "scheme": "VAT",
-                      "id": "DE123456789"
-                    }
-                  ]
+                  "tax_registration_number": "DE123456789"
                 },
                 "payment_means": [
                   {
@@ -814,12 +784,7 @@ paths:
                     "city": "Cologne",
                     "country": "DE"
                   },
-                  "tax_scheme": [
-                    {
-                      "scheme": "VAT",
-                      "id": "DE987654321"
-                    }
-                  ]
+                  "tax_registration_number": "DE987654321"
                 },
                 "accounting_customer_party": {
                   "name": "Example Buyer GmbH",
@@ -830,12 +795,7 @@ paths:
                     "city": "Berlin",
                     "country": "DE"
                   },
-                  "tax_scheme": [
-                    {
-                      "scheme": "VAT",
-                      "id": "DE123456789"
-                    }
-                  ]
+                  "tax_registration_number": "DE123456789"
                 },
                 "payment_means": [
                   {
@@ -2074,18 +2034,11 @@ components:
             address:
               description: Address of the Supplier party.
               $ref: '#/components/schemas/address'
-            tax_scheme:
-              type: array
-              description: List of tax identifiers associated with the supplier.
-              items:
-                $ref: '#/components/schemas/tax_scheme'
-            legal_entity:
-              description: Legal entity of the supplier party.
-              $ref: '#/components/schemas/party_legal_entity'
+            tax_registration_number:
+              type: string
+              description: Tax registration number of the supplier (for example VAT / GST number), when available.
           required:
             - address
-            - taxScheme
-            - legalEntity
         accounting_customer_party:
           type: object
           description: Party responsible for receiving the invoice (i.e., the customer).
@@ -2096,18 +2049,11 @@ components:
             address:
               description: Address of the customer party.
               $ref: '#/components/schemas/address'
-            tax_scheme:
-              type: array
-              description: List of tax identifiers associated.
-              items:
-                $ref: '#/components/schemas/tax_scheme'
-            legal_entity:
-              description: Legal entity of the customer party.
-              $ref: '#/components/schemas/party_legal_entity'
+            tax_registration_number:
+              type: string
+              description: Tax registration number of the customer (for example VAT / GST number), when available.
           required:
             - address
-            - taxScheme
-            - legalEntity
         payment_means:
           type: array
           description: A list of payment methods with corresponding payment details.
@@ -2755,18 +2701,6 @@ components:
         country:
           type: string
           description: ISO 3166-1 alpha-2 country code.
-    tax_scheme:
-      type: object
-      properties:
-        scheme:
-          type: string
-          description: A code identifying the tax regime under which this party is registered—such as VAT, GST, or a region-specific tax scheme. This enables the adapter or e‑invoicing provider to apply the correct tax logic or reporting rules.
-        id:
-          type: string
-          description: The tax identification number assigned to the party by the relevant authority (for example, VAT number or legal registration ID). It is used for official identification and compliance in the e‑invoicing process.
-      required:
-        - scheme
-        - id
     party_legal_entity:
       type: object
       description: Legal entity information of the party.

--- a/spec/spi/openapi_einvoicing.yml
+++ b/spec/spi/openapi_einvoicing.yml
@@ -561,7 +561,7 @@ paths:
                     },
                     {
                       "target": "Invoice.cac:AccountingCustomerParty.cac:Party.cac:PartyIdentification.cbc:ID.@schemeID\"",
-                      "source": "customer.cf_einvoice_scheme_id"
+                      "source": "custom_fields[cf_einvoice_scheme_id]"
                     },
                     {
                       "target": "Invoice.cac:TaxTotal.cbc:TaxAmount",
@@ -630,6 +630,7 @@ paths:
                     "invoice.note": "Payment due in 28 days.",
                     "business.address.country": "DE",
                     "customer.billing_address.country": "DE",
+                    "custom_fields[cf_einvoice_scheme_id]": "9930",
                     "invoice.tax_total": 14.0,
                     "line_items": [
                       {
@@ -865,7 +866,7 @@ paths:
                     },
                     {
                       "target": "Creditnote.cac:AccountingSupplierParty.cac:Party.cbc:EndpointID",
-                      "source": "business.legal_entity.company_id"
+                      "source": "tax_reg_number"
                     },
                     {
                       "target": "Creditnote.cac:AccountingSupplierParty.cac:Party.cac:PostalAddress.cac:Country.cbc:IdentificationCode",
@@ -873,11 +874,11 @@ paths:
                     },
                     {
                       "target": "Creditnote.cac:AccountingSupplierParty.cac:Party.cac:PartyLegalEntity.cbc:RegistrationName",
-                      "source": "business.legal_entity.registration_name"
+                      "source": "organization_details.organization_name"
                     },
                     {
                       "target": "Creditnote.cac:AccountingCustomerParty.cac:Party.cbc:EndpointID",
-                      "source": "customer.legal_entity.company_id"
+                      "source": "customer.vat_number"
                     },
                     {
                       "target": "Creditnote.cac:AccountingCustomerParty.cac:Party.cac:PostalAddress.cac:Country.cbc:IdentificationCode",
@@ -885,11 +886,11 @@ paths:
                     },
                     {
                       "target": "Creditnote.cac:AccountingCustomerParty.cac:Party.cac:PartyLegalEntity.cbc:RegistrationName",
-                      "source": "customer.legal_entity.registration_name"
+                      "source": "customer.company"
                     },
                     {
                       "target": "Invoice.cac:AccountingCustomerParty.cac:Party.cac:PartyIdentification.cbc:ID.@schemeID\"",
-                      "source": "customer.cf_einvoice_scheme_id"
+                      "source": "custom_fields[cf_einvoice_scheme_id]"
                     },
                     {
                       "target": "Creditnote.cac:TaxTotal.cbc:TaxAmount",
@@ -959,11 +960,12 @@ paths:
                     },
                     "credit_note.note": "Refund for April invoice",
                     "business.address.country": "DE",
-                    "business.legal_entity.company_id": "987654321",
-                    "business.legal_entity.registration_name": "Example Seller GmbH",
+                    "tax_reg_number": "DE987654321",
+                    "organization_details.organization_name": "Example Seller GmbH",
                     "customer.billing_address.country": "DE",
-                    "customer.legal_entity.company_id": "123456789",
-                    "customer.legal_entity.registration_name": "Example Buyer GmbH",
+                    "customer.vat_number": "DE123456789",
+                    "customer.company": "Example Buyer GmbH",
+                    "custom_fields[cf_einvoice_scheme_id]": "9930",
                     "credit_note.tax_total": 40.0,
                     "invoiceResponse": {
                     "events": [
@@ -1028,16 +1030,12 @@ paths:
                 "document_type": "ubl-applicationresponse",
                 "issue_date": "2025-04-04",
                 "sender_party": {
-                  "legal_entity": {
-                    "registration_name": "Example Sender GmbH",
-                    "company_id": "DE998877665"
-                  }
+                  "name": "Example Sender GmbH",
+                  "tax_registration_number": "DE987654321"
                 },
                 "receiver_party": {
-                  "legal_entity": {
-                    "registration_name": "Example Receiver GmbH",
-                    "company_id": "DE112233445"
-                  }
+                  "name": "Example Receiver GmbH",
+                  "tax_registration_number": "DE123456789"
                 },
                 "document_response": {
                   "response": {
@@ -1066,16 +1064,12 @@ paths:
                 "document_type": "ubl-applicationresponse",
                 "issue_date": "2025-04-03",
                 "sender_party": {
-                  "legal_entity": {
-                    "registration_name": "Example Sender GmbH",
-                    "company_id": "DE123456789"
-                  }
+                  "name": "Example Sender GmbH",
+                  "tax_registration_number": "DE987654321"
                 },
                 "receiver_party": {
-                  "legal_entity": {
-                    "registration_name": "Example Receiver GmbH",
-                    "company_id": "DE987654321"
-                  }
+                  "name": "Example Receiver GmbH",
+                  "tax_registration_number": "DE123456789"
                 },
                 "document_response": {
                   "response": {
@@ -1102,11 +1096,11 @@ paths:
                     },
                     {
                       "target": "ApplicationResponse.cac:SenderParty.cac:PartyLegalEntity.cbc:RegistrationName",
-                      "source": "application_response.sender_party.legal_entity.registration_name"
+                      "source": "application_response.sender_party.name"
                     },
                     {
                       "target": "ApplicationResponse.cac:ReceiverParty.cac:PartyLegalEntity.cbc:RegistrationName",
-                      "source": "application_response.receiver_party.legal_entity.registration_name"
+                      "source": "application_response.receiver_party.name"
                     },
                     {
                       "target": "ApplicationResponse.cac:DocumentResponse.cac:Response.cbc:ResponseCode",
@@ -1124,8 +1118,8 @@ paths:
                   "values": {
                     "application_response.id": "APPRESP-20240401-001",
                     "application_response.issue_date": "2025-04-03",
-                    "application_response.sender_party.legal_entity.registration_name": "Example Sender GmbH",
-                    "application_response.receiver_party.legal_entity.registration_name": "Example Receiver GmbH",
+                    "application_response.sender_party.name": "Example Sender GmbH",
+                    "application_response.receiver_party.name": "Example Receiver GmbH",
                     "application_response.document_response.response.status": "Accepted",
                     "application_response.document_response.response.note": "Invoice accepted without issues",
                     "application_response.document_response.document_reference.id": "INV-20240330-567"
@@ -2203,18 +2197,22 @@ components:
           format: date
         sender_party:
           type: object
-          required:
-            - legal_entity
           properties:
-            legal_entity:
-              $ref: '#/components/schemas/party_legal_entity'
+            name:
+              type: string
+              description: Name of the sender party.
+            tax_registration_number:
+              type: string
+              description: Tax registration number of the sender (for example VAT / GST number), when available.
         receiver_party:
           type: object
-          required:
-            - legal_entity
           properties:
-            legal_entity:
-              $ref: '#/components/schemas/party_legal_entity'
+            name:
+              type: string
+              description: Name of the receiver party.
+            tax_registration_number:
+              type: string
+              description: Tax registration number of the receiver (for example VAT / GST number), when available.
         document_response:
           type: object
           required:
@@ -2701,19 +2699,6 @@ components:
         country:
           type: string
           description: ISO 3166-1 alpha-2 country code.
-    party_legal_entity:
-      type: object
-      description: Legal entity information of the party.
-      properties:
-        registration_name:
-          type: string
-          description: The full formal name by which the party is registered.
-        company_id:
-          type: string
-          description: An identifier issued by an official registrar that identifies
-            the party as a legal entity or person.
-      required:
-        - registrationName
     callback_document_status:
       type: object
       properties:

--- a/spec/spi/openapi_einvoicing.yml
+++ b/spec/spi/openapi_einvoicing.yml
@@ -2221,23 +2221,11 @@ components:
           type: string
           format: date
         sender_party:
-          type: object
-          properties:
-            name:
-              type: string
-              description: Name of the sender party.
-            tax_registration_number:
-              type: string
-              description: Tax registration number of the sender (for example VAT / GST number), when available.
+          description: Party that sends the application response.
+          $ref: '#/components/schemas/application_response_party'
         receiver_party:
-          type: object
-          properties:
-            name:
-              type: string
-              description: Name of the receiver party.
-            tax_registration_number:
-              type: string
-              description: Tax registration number of the receiver (for example VAT / GST number), when available.
+          description: Party that receives the application response.
+          $ref: '#/components/schemas/application_response_party'
         document_response:
           type: object
           required:
@@ -2700,6 +2688,16 @@ components:
         - REFUNDED
         - REFUND_DUE
       example: PAYMENT_DUE
+    application_response_party:
+      type: object
+      description: Party information for the sender or receiver of an application response document.
+      properties:
+        name:
+          type: string
+          description: Name of the party.
+        tax_registration_number:
+          type: string
+          description: Tax registration number of the party (for example VAT / GST number), when available.
     address:
       type: object
       properties:


### PR DESCRIPTION
## CHANGELOG
- Removed unused `tax_scheme` and `legal_entity` from `accounting_supplier_party` and `accounting_customer_party` in the e-invoicing OpenAPI schema
- Added optional `tax_registration_number` (string) on both supplier and customer parties
- Updated request/response examples to use `tax_registration_number`
- Kept `party_legal_entity` for application_response sender/receiver parties

## SUMMARY
SPI e-invoicing party models no longer expose unused `tax_scheme` / `legal_entity` on invoice/credit-note parties. Providers and Chargebee now contract on a single optional `tax_registration_number` for supplier and customer tax registration / VAT identity.

## FUNCTIONAL AUTOMATION CHANGES PR
- [ ] Yes
  - If Yes, PR : 
- [x] No
  - If No, Reason: SPI OpenAPI schema-only change; no functional automation impacted

## AUTOMATION TEST REPORT URL
NA

## AREAS OF IMPACT
- E-invoicing SPI OpenAPI (`openapi_einvoicing.yml`) — supplier/customer party schemas and examples
- Downstream consumers of generated SPI models (`MainDocumentAccountingSupplierParty` / `MainDocumentAccountingCustomerParty`) — Chargebee app transformers and partner providers that map these fields
- Application response parties unchanged (`legal_entity` retained there)

## TYPE OF CHANGE
- [ ] 🐞 Bugfix
- [ ] 🌟 Feature
- [x] ✨ Enhancement
- [ ] 🧪 Unit Test Cases
- [ ] 📔 Documentation
- [ ] ⚙️ Chore - Build Related / Configuration / Others

## DOCUMENTATION
NA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the e-invoicing OpenAPI schema to replace unused party `tax_scheme` and `legal_entity` structures with optional `tax_registration_number` fields. Added a dedicated application-response party schema, retained legal-entity data where required, and updated request, response, and override examples to match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->